### PR TITLE
Change  texmath.cabal to require parsec >= 3

### DIFF
--- a/texmath.cabal
+++ b/texmath.cabal
@@ -74,7 +74,7 @@ Flag test
   default:           False
 
 Library
-    Build-depends:       xml, parsec >= 2, containers
+    Build-depends:       xml, parsec >= 3, containers
     if impl(ghc >= 6.10)
       Build-depends: base >= 4 && < 5, syb
     else


### PR DESCRIPTION
Text/TeXMath/Parser.hs uses the Applicative instance of Parsec,
and so needs parsec-3.0.0 or later.
