### PR TITLE
Fix multiple sub/superscript issues

### DIFF
--- a/Text/TeXMath/Parser.hs
+++ b/Text/TeXMath/Parser.hs
@@ -246,17 +246,24 @@ variable = do
 
 isConvertible :: Exp -> Bool
 isConvertible (EMathOperator x) = x `elem` convertibleOps
-  where convertibleOps = ["lim","liminf","limsup","inf","sup","min","max","Pr","det","gcd"]
+  where convertibleOps = [ "lim","liminf","limsup","inf","sup"
+                         , "min","max","Pr","det","gcd"
+                         ]
 isConvertible (ESymbol Rel _) = True
 isConvertible (ESymbol Bin _) = True
-isConvertible (EUnder _ _)    = True
-isConvertible (EOver _ _)     = True
-isConvertible (EUnderover _ _ _) = True
 isConvertible (ESymbol Op x) = x `elem` convertibleSyms
   where convertibleSyms = ["\x2211","\x220F","\x22C2",
            "\x22C3","\x22C0","\x22C1","\x2A05","\x2A06",
            "\x2210","\x2A01","\x2A02","\x2A00","\x2A04"]
 isConvertible _ = False
+
+-- check if sub/superscripts should always be under and over the expression
+isUnderover :: Exp -> Bool
+isUnderover (EOver _ (ESymbol Accent "\xFE37")) = True   -- \overbrace
+isUnderover (EOver _ (ESymbol Accent "\x23B4")) = True   -- \overbracket
+isUnderover (EUnder _ (ESymbol Accent "\xFE38")) = True  -- \underbrace
+isUnderover (EUnder _ (ESymbol Accent "\x23B5")) = True  -- \underbracket
+isUnderover _ = False
 
 subSup :: Maybe Bool -> Exp -> TP Exp
 subSup limits a = try $ do
@@ -267,6 +274,7 @@ subSup limits a = try $ do
   return $ case limits of
             Just True  -> EUnderover a b c
             Nothing | isConvertible a -> EDownup a b c
+                    | isUnderover a -> EUnderover a b c
             _          -> ESubsup a b c
 
 superOrSubscripted :: Maybe Bool -> Exp -> TP Exp
@@ -278,10 +286,12 @@ superOrSubscripted limits a = try $ do
        '^' -> return $ case limits of
                         Just True  -> EOver a b
                         Nothing | isConvertible a -> EUp a b
+                                | isUnderover a -> EOver a b
                         _          -> ESuper a b
        '_' -> return $ case limits of
                         Just True  -> EUnder a b
                         Nothing | isConvertible a -> EDown a b
+                                | isUnderover a -> EUnder a b
                         _          -> ESub a b
        _   -> pzero
 

--- a/tests/subsup.omml
+++ b/tests/subsup.omml
@@ -114,5 +114,198 @@
         </m:r>
       </m:lim>
     </m:limLow>
+    <m:sSup>
+      <m:e>
+        <m:acc>
+          <m:accPr>
+            <m:chr m:val="." />
+          </m:accPr>
+          <m:e>
+            <m:r>
+              <m:rPr />
+              <m:t>u</m:t>
+            </m:r>
+          </m:e>
+        </m:acc>
+      </m:e>
+      <m:sup>
+        <m:r>
+          <m:rPr />
+          <m:t>2</m:t>
+        </m:r>
+      </m:sup>
+    </m:sSup>
+    <m:sSub>
+      <m:e>
+        <m:bar>
+          <m:barPr>
+            <m:pos m:val="top" />
+          </m:barPr>
+          <m:e>
+            <m:r>
+              <m:rPr />
+              <m:t>u</m:t>
+            </m:r>
+          </m:e>
+        </m:bar>
+      </m:e>
+      <m:sub>
+        <m:r>
+          <m:rPr />
+          <m:t>ɛ</m:t>
+        </m:r>
+      </m:sub>
+    </m:sSub>
+    <m:sSubSup>
+      <m:e>
+        <m:bar>
+          <m:barPr>
+            <m:pos m:val="bot" />
+          </m:barPr>
+          <m:e>
+            <m:r>
+              <m:rPr />
+              <m:t>u</m:t>
+            </m:r>
+          </m:e>
+        </m:bar>
+      </m:e>
+      <m:sub>
+        <m:r>
+          <m:rPr />
+          <m:t>b</m:t>
+        </m:r>
+      </m:sub>
+      <m:sup>
+        <m:r>
+          <m:rPr />
+          <m:t>a</m:t>
+        </m:r>
+      </m:sup>
+    </m:sSubSup>
+    <m:limUpp>
+      <m:e>
+        <m:acc>
+          <m:accPr>
+            <m:chr m:val="︷" />
+          </m:accPr>
+          <m:e>
+            <m:r>
+              <m:rPr />
+              <m:t>a</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>+</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>b</m:t>
+            </m:r>
+          </m:e>
+        </m:acc>
+      </m:e>
+      <m:lim>
+        <m:r>
+          <m:rPr>
+            <m:sty m:val="p" />
+          </m:rPr>
+          <m:t>term</m:t>
+        </m:r>
+      </m:lim>
+    </m:limUpp>
+    <m:limUpp>
+      <m:e>
+        <m:acc>
+          <m:accPr>
+            <m:chr m:val="⎴" />
+          </m:accPr>
+          <m:e>
+            <m:r>
+              <m:rPr />
+              <m:t>a</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>+</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>b</m:t>
+            </m:r>
+          </m:e>
+        </m:acc>
+      </m:e>
+      <m:lim>
+        <m:r>
+          <m:rPr />
+          <m:t>c</m:t>
+        </m:r>
+      </m:lim>
+    </m:limUpp>
+    <m:limLow>
+      <m:e>
+        <m:limLow>
+          <m:e>
+            <m:r>
+              <m:rPr />
+              <m:t>a</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>+</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>b</m:t>
+            </m:r>
+          </m:e>
+          <m:lim>
+            <m:r>
+              <m:rPr />
+              <m:t>︸</m:t>
+            </m:r>
+          </m:lim>
+        </m:limLow>
+      </m:e>
+      <m:lim>
+        <m:r>
+          <m:rPr />
+          <m:t>c</m:t>
+        </m:r>
+      </m:lim>
+    </m:limLow>
+    <m:limLow>
+      <m:e>
+        <m:limLow>
+          <m:e>
+            <m:r>
+              <m:rPr />
+              <m:t>a</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>+</m:t>
+            </m:r>
+            <m:r>
+              <m:rPr />
+              <m:t>b</m:t>
+            </m:r>
+          </m:e>
+          <m:lim>
+            <m:r>
+              <m:rPr />
+              <m:t>⎵</m:t>
+            </m:r>
+          </m:lim>
+        </m:limLow>
+      </m:e>
+      <m:lim>
+        <m:r>
+          <m:rPr />
+          <m:t>c</m:t>
+        </m:r>
+      </m:lim>
+    </m:limLow>
   </m:oMath>
 </m:oMathPara>

--- a/tests/subsup.tex
+++ b/tests/subsup.tex
@@ -1,1 +1,4 @@
  x^a_b x_b^a \min_A \max_B \det_C \Pr_A \gcd_A
+ \dot{u}^2 \overline{u}_\varepsilon \underline{u}^a_b
+ \overbrace{a+b}^{\text{term}} \overbracket{a+b}^{c}
+ \underbrace{a+b}_{c} \underbracket{a+b}_{c}

--- a/tests/subsup.xhtml
+++ b/tests/subsup.xhtml
@@ -36,6 +36,72 @@
           <mi>gcd</mi>
           <mi>A</mi>
         </munder>
+        <msup>
+          <mover>
+            <mi>u</mi>
+            <mo accent="true">.</mo>
+          </mover>
+          <mn>2</mn>
+        </msup>
+        <msub>
+          <mover>
+            <mi>u</mi>
+            <mo accent="true">¯</mo>
+          </mover>
+          <mi>ɛ</mi>
+        </msub>
+        <msubsup>
+          <munder>
+            <mi>u</mi>
+            <mo accent="true">¯</mo>
+          </munder>
+          <mi>b</mi>
+          <mi>a</mi>
+        </msubsup>
+        <mover>
+          <mover>
+            <mrow>
+              <mi>a</mi>
+              <mo>+</mo>
+              <mi>b</mi>
+            </mrow>
+            <mo accent="true">︷</mo>
+          </mover>
+          <mtext mathvariant="normal">term</mtext>
+        </mover>
+        <mover>
+          <mover>
+            <mrow>
+              <mi>a</mi>
+              <mo>+</mo>
+              <mi>b</mi>
+            </mrow>
+            <mo accent="true">⎴</mo>
+          </mover>
+          <mi>c</mi>
+        </mover>
+        <munder>
+          <munder>
+            <mrow>
+              <mi>a</mi>
+              <mo>+</mo>
+              <mi>b</mi>
+            </mrow>
+            <mo accent="true">︸</mo>
+          </munder>
+          <mi>c</mi>
+        </munder>
+        <munder>
+          <munder>
+            <mrow>
+              <mi>a</mi>
+              <mo>+</mo>
+              <mi>b</mi>
+            </mrow>
+            <mo accent="true">⎵</mo>
+          </munder>
+          <mi>c</mi>
+        </munder>
       </mrow>
     </math>
   </body>


### PR DESCRIPTION
Dear John,

these two commits fix a couple issues with sub/superscript placement:
- treat operators `\max`, `\min`, `\Pr`, `\det`, `\gcd` as 'convertible', to match the correct LaTeX behavior, i.e `\lim`;
  see [amsopn.dtx](http://web.mit.edu/texsrc/source/latex/amsmath/amsopn.dtx) for reference
- accents (as in `\dot{u}` or `\underline{u}`) should _never_ be 'convertible' as far as I can tell;
   the proper behavior is to always place sub/superscript as sub/superscript in both inline and block display,
   with the exception of `\overbrace`/`\underbrace` and `\overbracket`/`\underbracket`, where sub/superscript is always placed under/over
- `subsup.tex,.xhtml,.omml` test suite seems to be missing, producing an error when building with cabal;
  I created the file and included a couple of tests

All tests PASS.

Best,
Norbert
