### PR TITLE
Treat \ commands as tex tokens in arguments

### DIFF
--- a/Text/TeXMath/Parser.hs
+++ b/Text/TeXMath/Parser.hs
@@ -97,7 +97,7 @@ inbraces :: TP Exp
 inbraces = liftM EGrouped (braces $ many $ notFollowedBy (char '}') >> expr)
 
 texToken :: TP Exp
-texToken = inbraces <|> inbrackets <|>
+texToken = texSymbol <|> inbraces <|> inbrackets <|>
              do c <- anyChar
                 spaces
                 return $ if isDigit c

--- a/tests/tokens.omml
+++ b/tests/tokens.omml
@@ -1,0 +1,110 @@
+<?xml version='1.0' ?>
+<m:oMathPara>
+  <m:oMathParaPr>
+    <m:jc m:val="center" />
+  </m:oMathParaPr>
+  <m:oMath>
+    <m:acc>
+      <m:accPr>
+        <m:chr m:val="~" />
+      </m:accPr>
+      <m:e>
+        <m:r>
+          <m:rPr />
+          <m:t>ϕ</m:t>
+        </m:r>
+      </m:e>
+    </m:acc>
+    <m:rad>
+      <m:radPr>
+        <m:degHide m:val="on" />
+      </m:radPr>
+      <m:deg />
+      <m:e>
+        <m:r>
+          <m:rPr />
+          <m:t>ϕ</m:t>
+        </m:r>
+      </m:e>
+    </m:rad>
+    <m:f>
+      <m:fPr>
+        <m:type m:val="bar" />
+      </m:fPr>
+      <m:num>
+        <m:r>
+          <m:rPr />
+          <m:t>ϕ</m:t>
+        </m:r>
+      </m:num>
+      <m:den>
+        <m:r>
+          <m:rPr />
+          <m:t>ξ</m:t>
+        </m:r>
+      </m:den>
+    </m:f>
+    <m:f>
+      <m:fPr>
+        <m:type m:val="bar" />
+      </m:fPr>
+      <m:num>
+        <m:r>
+          <m:rPr />
+          <m:t>ϕ</m:t>
+        </m:r>
+      </m:num>
+      <m:den>
+        <m:r>
+          <m:rPr />
+          <m:t>ξ</m:t>
+        </m:r>
+      </m:den>
+    </m:f>
+    <m:f>
+      <m:fPr>
+        <m:type m:val="bar" />
+      </m:fPr>
+      <m:num>
+        <m:r>
+          <m:rPr />
+          <m:t>ϕ</m:t>
+        </m:r>
+      </m:num>
+      <m:den>
+        <m:r>
+          <m:rPr />
+          <m:t>ξ</m:t>
+        </m:r>
+      </m:den>
+    </m:f>
+    <m:r>
+      <m:rPr />
+      <m:t>(</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr />
+      <m:t>ϕ</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr />
+      <m:t>)</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr />
+      <m:t>(</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr />
+      <m:t>ϕ</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr />
+      <m:t>)</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr />
+      <m:t>ξ</m:t>
+    </m:r>
+  </m:oMath>
+</m:oMathPara>

--- a/tests/tokens.tex
+++ b/tests/tokens.tex
@@ -1,0 +1,17 @@
+\newcommand{\my}[1]{(#1)}
+
+
+% diacritics
+\tilde\phi
+
+% unary operators
+\sqrt\phi
+
+% binary operators
+\frac\phi\xi
+\frac \phi {\xi}
+\frac {\phi} \xi
+
+% custom
+\my\phi
+\my{\phi}\xi

--- a/tests/tokens.xhtml
+++ b/tests/tokens.xhtml
@@ -1,0 +1,38 @@
+<?xml version='1.0' ?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta content="application/xhtml+xml; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <math display="block" xmlns="http://www.w3.org/1998/Math/MathML">
+      <mrow>
+        <mover>
+          <mi>ϕ</mi>
+          <mo accent="true">~</mo>
+        </mover>
+        <msqrt>
+          <mi>ϕ</mi>
+        </msqrt>
+        <mfrac>
+          <mi>ϕ</mi>
+          <mi>ξ</mi>
+        </mfrac>
+        <mfrac>
+          <mi>ϕ</mi>
+          <mi>ξ</mi>
+        </mfrac>
+        <mfrac>
+          <mi>ϕ</mi>
+          <mi>ξ</mi>
+        </mfrac>
+        <mo stretchy="false">(</mo>
+        <mi>ϕ</mi>
+        <mo stretchy="false">)</mo>
+        <mo stretchy="false">(</mo>
+        <mi>ϕ</mi>
+        <mo stretchy="false">)</mo>
+        <mi>ξ</mi>
+      </mrow>
+    </math>
+  </body>
+</html>


### PR DESCRIPTION
This is a simple fix of a problem when parsing command arguments not surrounded by braces that are themselves \ commands:

``` latex
\tilde\phi
```

This gets currently interpreted as 

``` latex
\tilde{\}phi
```

while the correct tex behavior is

``` latex
\tilde{\phi}
```

This patch just adds `texSymbol` parser as an option of the `texToken` parser. In my opinion, this is the intended behavior. Now all commands, including unary (`\sqrt`), binary (`\frac`) and custom commands work properly with \ command arguments; see `tests/tokens.tex`.

_Remark._ Note that there is still some inconsistency with the way texmath parses arguments of sub/superscript using the `expr1` parser. I think this should be replaced by `texToken` parser, for consistency with latex, but I haven't touched that.

All tests pass.
