### PR TITLE
Add support for bm

### DIFF
--- a/Text/TeXMath/Parser.hs
+++ b/Text/TeXMath/Parser.hs
@@ -356,6 +356,7 @@ textOps = M.fromList
           , ("\\mathbffrak", EText TextBoldFraktur)
           , ("\\mathbfcal",  EText TextBoldScript)
           , ("\\mathsfit",   EText TextSansSerifItalic)
+          , ("\\bm",         EText TextBoldItalic)
           ]
 
 parseText :: String -> String

--- a/tests/22.omml
+++ b/tests/22.omml
@@ -134,6 +134,11 @@
               <m:mcJc m:val="left" />
             </m:mcPr>
           </m:mc>
+          <m:mc>
+            <m:mcPr>
+              <m:mcJc m:val="left" />
+            </m:mcPr>
+          </m:mc>
         </m:mcs>
       </m:mPr>
       <m:mr>
@@ -620,6 +625,25 @@
             <m:rPr>
               <m:sty m:val="i" />
               <m:scr m:val="sans-serif" />
+            </m:rPr>
+            <m:t>ABCabc</m:t>
+          </m:r>
+        </m:e>
+      </m:mr>
+      <m:mr>
+        <m:e>
+          <m:r>
+            <m:rPr>
+              <m:sty m:val="p" />
+              <m:scr m:val="monospace" />
+            </m:rPr>
+            <m:t>bm</m:t>
+          </m:r>
+        </m:e>
+        <m:e>
+          <m:r>
+            <m:rPr>
+              <m:sty m:val="i" />
             </m:rPr>
             <m:t>ABCabc</m:t>
           </m:r>

--- a/tests/22.tex
+++ b/tests/22.tex
@@ -23,6 +23,7 @@
 \texttt{mathbfscr}  & \mathbfscr {ABCabc} \\
 \texttt{mathbffrak} & \mathbffrak{ABCabc} \\
 \texttt{mathbfcal}  & \mathbfcal {ABCabc} \\
-\texttt{mathsfit}   & \mathsfit  {ABCabc}
+\texttt{mathsfit}   & \mathsfit  {ABCabc} \\
+\texttt{bm}         & \bm        {ABCabc}
 \end{array}
 

--- a/tests/22.xhtml
+++ b/tests/22.xhtml
@@ -207,6 +207,14 @@
               <mtext mathvariant="sans-serif-italic">ABCabc</mtext>
             </mtd>
           </mtr>
+          <mtr>
+            <mtd columnalign="left">
+              <mtext mathvariant="monospace">bm</mtext>
+            </mtd>
+            <mtd columnalign="left">
+              <mtext mathvariant="bold-italic">ABCabc</mtext>
+            </mtd>
+          </mtr>
         </mtable>
       </mrow>
     </math>


### PR DESCRIPTION
This PR adds partial support for `\bm` (http://www.ctan.org/pkg/bm).
