### PR TITLE
TexMath Writer: Don't brace first exp in `bin`

### DIFF
--- a/src/Text/TeXMath/Writers/TeXMath.hs
+++ b/src/Text/TeXMath/Writers/TeXMath.hs
@@ -137,7 +137,7 @@ underOver :: Exp -> Exp -> Exp -> String
 underOver b e1 e2 = bin "_" b e1 ++ "^" ++ evalInBraces e2
 
 bin :: String -> Exp -> Exp -> String
-bin s b e = evalInBraces b ++ s ++ evalInBraces e
+bin s b e = writeExp b ++ s ++ evalInBraces e
 
 evalInBraces :: Exp -> String
 evalInBraces = inBraces  . writeExp


### PR DESCRIPTION
ping @mpickering

(Per our conversation the other day. I'd have submitted to you, but I wasn't sure which fork you were working off these days.)

Previously unders and overs in sums, integrals, lims, etc. didn't work
because of braces around the operator name. This removes that brace.
`bin` is only used in Overs and Under, so the first expression will
always be followed by `_` or `^`, and we therefore don't need to worry
about an alphanum following and messing up the operator name.
