### PR TITLE
MathML Parser: Improved handling of nested mstyle

### DIFF
--- a/src/Text/TeXMath/Readers/MathML.hs
+++ b/src/Text/TeXMath/Readers/MathML.hs
@@ -166,8 +166,11 @@ space e = do
 
 style :: Element -> MML Exp
 style e = do
-  textStyle <- maybe TextNormal getTextType <$> (findAttrQ "mathvariant" e)
-  EStyled textStyle <$> group e
+  constructor <- maybe EGrouped (EStyled . getTextType) <$> (findAttrQ "mathvariant" e)
+  -- We do not want to propagate the mathvariant else
+  -- we end up with nested EStyled applying the same
+  -- style
+  constructor <$> local filterMathVariant (group e)
 
 row :: Element -> MML Exp
 row e = EGrouped <$> group e
@@ -369,6 +372,10 @@ def = MMLState [] Nothing
 
 addAttrs :: [Attr] -> MMLState -> MMLState
 addAttrs as s = s {attrs = as ++ attrs s }
+
+filterMathVariant :: MMLState -> MMLState
+filterMathVariant s@(attrs -> as) =
+  s{attrs = filter ((/= unqual "mathvariant") . attrKey) as}
 
 setPosition :: FormType -> MMLState -> MMLState
 setPosition p s = s {position = Just p}


### PR DESCRIPTION
Before this patch, the mathvariant would propogate downwards and pollute nested
style elements. These would be needlessly styled which cluttered output
code. We also do not select a style unless one is explicitly selected by the value in the mathvariant.
