### PR TITLE
OMML reader: change default accent.

### DIFF
--- a/src/Text/TeXMath/Readers/OMML.hs
+++ b/src/Text/TeXMath/Readers/OMML.hs
@@ -233,7 +233,7 @@ elemToExps' element | isElem "m" "acc" element = do
             Just . head
       chr' = case chr of
         Just c -> c
-        Nothing -> '\180'       -- default to acute.
+        Nothing -> '^'       -- default to hat.
   baseExp <- filterChildName (hasElemName "m" "e") element >>=
              elemToBase
   return $ [EOver False baseExp (ESymbol Accent [chr'])]


### PR DESCRIPTION
The default had previously been set as accute (possibly as a placeholder).
It appears to be circumflex/hat instead. This corrects the error.
