### PR TITLE
Support \ltimes and \rtimes in the TeX reader.

### DIFF
--- a/src/Text/TeXMath/Readers/TeX.hs
+++ b/src/Text/TeXMath/Readers/TeX.hs
@@ -719,6 +719,8 @@ symbols = M.fromList
            , ("\\backslash", ESymbol Bin "\x2216")
            , ("\\setminus", ESymbol Bin "\\")
            , ("\\times", ESymbol Bin "\x00D7")
+           , ("\\ltimes", ESymbol Bin "\x22C9")
+           , ("\\rtimes", ESymbol Bin "\x22CA")
            , ("\\alpha", EIdentifier "\x03B1")
            , ("\\beta", EIdentifier "\x03B2")
            , ("\\chi", EIdentifier "\x03C7")


### PR DESCRIPTION
Maps `\ltimes` into ‘⋉’ (U+22C9 LEFT NORMAL FACTOR SEMIDIRECT PRODUCT) and `\rtimes` into ‘⋊’ (U+22CA RIGHT NORMAL FACTOR SEMIDIRECT PRODUCT) in the TeX reader.