### PR TITLE
Set more accurate bounds

### DIFF
--- a/texmath.cabal
+++ b/texmath.cabal
@@ -86,12 +86,9 @@ Flag network-uri
   default: True
 
 Library
-    Build-depends:       xml, parsec >= 3, containers,
+    Build-depends:       base >= 4.8 && < 5, syb >= 0.4.2 && < 0.8, xml, parsec >= 3, containers,
                          pandoc-types >= 1.12.3.3 && < 1.18, mtl
-    if impl(ghc >= 6.10)
-      Build-depends: base >= 4.5 && < 5, syb
-    else
-      Build-depends: base >= 3 && < 4
+    
     Exposed-modules:     Text.TeXMath,
                          Text.TeXMath.Types,
                          Text.TeXMath.TeX,
@@ -132,7 +129,7 @@ Executable texmath
     Ghc-Prof-Options:  -fprof-auto-exported
     if flag(executable)
       Buildable:         True
-      Build-Depends:     base >= 4.5 && < 5, texmath, xml,
+      Build-Depends:     base >= 4.8 && < 5, texmath, xml,
                          pandoc-types >= 1.12.3.3 && < 1.18,
                          split, aeson, bytestring, text
     else
@@ -146,7 +143,7 @@ Test-Suite test-texmath
     Type:                exitcode-stdio-1.0
     Main-Is:             test-texmath.hs
     Hs-Source-Dirs:      tests
-    Build-Depends:       base >= 4.2 && < 5, process, directory, filepath,
+    Build-Depends:       base >= 4.8 && < 5, process, directory, filepath,
                          texmath, xml, utf8-string, bytestring, process,
                          temporary, text, split
     Default-Language:    Haskell2010


### PR DESCRIPTION
I jus thad to fixup the lower bound on `base` at

https://hackage.haskell.org/package/texmath-0.11.1.1/revisions/

because the cabal solver would otherwise happily try to build `texmath-0.11.1.1` w/ `base-4.7`:

```
[18 of 20] Compiling Text.TeXMath.Readers.MathML ( src/Text/TeXMath/Readers/MathML.hs, /tmp/matrix-worker/1538177809/dist-newstyle/build/x86_64-linux/ghc-7.8.4/texmath-0.11.1.1/build/Text/TeXMath/Readers/MathML.o )

src/Text/TeXMath/Readers/MathML.hs:155:30: Not in scope: ‘pure’
```