### PR TITLE
Switch texmath to Text

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,6 @@
 packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/jgm/pandoc-types
+    tag: f63baa73ae9a353b1896b008a145ebf1ef9a0342

--- a/src/Text/TeXMath.hs
+++ b/src/Text/TeXMath.hs
@@ -24,9 +24,10 @@ Also note that in general @writeLaTeX . readLaTeX /= id@.
 A typical use is to combine together a reader and writer.
 
 > import Control.Applicative ((<$>))
+> import Data.Text (Text)
 > import Text.TeXMath (writeMathML, readTeX)
 >
-> texMathToMathML :: DisplayType -> String -> Either String Element
+> texMathToMathML :: DisplayType -> Text -> Either Text Element
 > texMathToMathML dt s = writeMathML dt <$> readTeX s
 
 It is also possible to manipulate the AST using 'Data.Generics'. For
@@ -34,20 +35,24 @@ example, if you wanted to replace all occurences of the identifier
 x in your expression, you do could do so with the following
 script.
 
-> import Control.Applicative ((<$>))
-> import Data.Generics (everywhere, mkT)
-> import Text.TeXMath (writeMathML, readTeX)
-> import Text.TeXMath.Types
-> import Text.XML.Light (Element)
->
-> changeIdent :: Exp -> Exp
-> changeIdent (EIdentifier "x") = EIdentifier "y"
-> changeIdent e = e
->
-> texToMMLWithChangeIdent :: DisplayType -> String -> Either String Element
-> texToMMLWithChangeIdent dt s =
->   writeMathML dt . everywhere (mkT changeIdent) <$> readTeX s
+@
+&#x7b;-\# LANGUAGE OverloadedStrings -\#&#x7d;
 
+import Control.Applicative ((\<$\>))
+import Data.Text (Text)
+import Data.Generics (everywhere, mkT)
+import Text.TeXMath (writeMathML, readTeX)
+import Text.TeXMath.Types
+import Text.XML.Light (Element)
+
+changeIdent :: Exp -> Exp
+changeIdent (EIdentifier "x") = EIdentifier "y"
+changeIdent e = e
+
+texToMMLWithChangeIdent :: DisplayType -> Text -> Either Text Element
+texToMMLWithChangeIdent dt s =
+  writeMathML dt . everywhere (mkT changeIdent) \<$\> readTeX s
+@
 -}
 
 module Text.TeXMath ( readMathML,

--- a/src/Text/TeXMath/Readers/MathML/EntityMap.hs
+++ b/src/Text/TeXMath/Readers/MathML/EntityMap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-
 Copyright (C) 2014 Matthew Pickering <matthewtpickering@gmail.com>
 
@@ -33,12 +34,13 @@ in MathML+LaTeX.  See http://www.w3.org/2003/entities/2007doc/#epsilon.
 module Text.TeXMath.Readers.MathML.EntityMap (getUnicode) where
 
 import qualified Data.Map as M
+import qualified Data.Text as T
 
 -- | Translates MathML entity reference to the corresponding Unicode string.
-getUnicode :: String -> Maybe String
+getUnicode :: T.Text -> Maybe T.Text
 getUnicode = flip M.lookup entityList
 
-entityList :: M.Map String String
+entityList :: M.Map T.Text T.Text
 entityList = M.fromList
   [ ("AElig","\198")
   , ("AMP","&")

--- a/src/Text/TeXMath/Readers/MathML/MMLDict.hs
+++ b/src/Text/TeXMath/Readers/MathML/MMLDict.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-
 Copyright (C) 2014 Matthew Pickering <matthewtpickering@gmail.com>
 
@@ -25,15 +26,16 @@ module Text.TeXMath.Readers.MathML.MMLDict (getMathMLOperator, operators) where
 
 import Text.TeXMath.Types
 import qualified Data.Map as M
+import qualified Data.Text as T
 import Data.Monoid (First(..), mconcat)
 
-dict :: M.Map (String, FormType) Operator
+dict :: M.Map (T.Text, FormType) Operator
 dict = M.fromList (map (\o -> ((oper o, form o), o)) operators)
 
 -- | Tries to find the 'Operator' record based on a given position. If
 -- there is no exact match then the positions will be tried in the
 -- following order (Infix, Postfix, Prefix) with the first match (if any) being returned.
-getMathMLOperator :: String -> FormType -> Maybe Operator
+getMathMLOperator :: T.Text -> FormType -> Maybe Operator
 getMathMLOperator s p =
   getFirst $ mconcat $ (map (\x -> First $ M.lookup (s, x) dict) lookupOrder)
   where

--- a/src/Text/TeXMath/Shared.hs
+++ b/src/Text/TeXMath/Shared.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, ScopedTypeVariables, OverloadedStrings #-}
 {-
 Copyright (C) 2014 Matthew Pickering <matthewtpickering@gmail.com>
 
@@ -40,9 +40,11 @@ import Text.TeXMath.Types
 import Text.TeXMath.TeX
 import qualified Data.Map as M
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import Data.Maybe (fromMaybe)
 import Data.Ratio ((%))
 import Data.List (sort)
+import Data.Semigroup ((<>))
 import Control.Applicative ((<$>), (<*>))
 import Control.Monad (guard)
 import Text.Parsec (Parsec, parse, getInput, digit, char, many1, option)
@@ -74,11 +76,11 @@ fixTree :: Exp -> Exp
 fixTree = everywhere (mkT removeNesting) . everywhere (mkT removeEmpty)
 
 -- | Maps TextType to the corresponding MathML mathvariant
-getMMLType :: TextType -> String
+getMMLType :: TextType -> T.Text
 getMMLType t = fromMaybe "normal" (fst <$> M.lookup t textTypesMap)
 
 -- | Maps TextType to corresponding LaTeX command
-getLaTeXTextCommand :: Env -> TextType -> String
+getLaTeXTextCommand :: Env -> TextType -> T.Text
 getLaTeXTextCommand e t =
   let textCmd = fromMaybe "\\mathrm"
                   (snd <$> M.lookup t textTypesMap) in
@@ -87,11 +89,11 @@ getLaTeXTextCommand e t =
     else fromMaybe "\\mathrm" (M.lookup textCmd alts)
 
 -- | Maps MathML mathvariant to the corresponing TextType
-getTextType :: String -> TextType
+getTextType :: T.Text -> TextType
 getTextType s = fromMaybe TextNormal (M.lookup s revTextTypesMap)
 
 -- | Maps a LaTeX scaling command to the percentage scaling
-getScalerCommand :: Rational -> Maybe String
+getScalerCommand :: Rational -> Maybe T.Text
 getScalerCommand width =
   case sort [ (w, cmd) | (cmd, w) <- scalers, w >= width ] of
        ((_,cmd):_) -> Just cmd
@@ -100,11 +102,11 @@ getScalerCommand width =
   -- match:  \Big, not \Bigr
 
 -- | Gets percentage scaling from LaTeX scaling command
-getScalerValue :: String -> Maybe Rational
+getScalerValue :: T.Text -> Maybe Rational
 getScalerValue command = lookup command scalers
 
 -- | Given a diacritical mark, returns the corresponding LaTeX command
-getDiacriticalCommand  :: Position -> String -> Maybe String
+getDiacriticalCommand  :: Position -> T.Text -> Maybe T.Text
 getDiacriticalCommand pos symbol = do
   command <- M.lookup symbol diaMap
   guard (not $ command `elem` unavailable)
@@ -120,7 +122,7 @@ getDiacriticalCommand pos symbol = do
 getOperator :: Exp -> Maybe TeX
 getOperator op = fmap ControlSeq $ M.lookup op operators
 
-operators :: M.Map Exp String
+operators :: M.Map Exp T.Text
 operators = M.fromList
            [ (EMathOperator "arccos", "\\arccos")
            , (EMathOperator "arcsin", "\\arcsin")
@@ -156,7 +158,7 @@ operators = M.fromList
            , (EMathOperator "tanh", "\\tanh") ]
 
 -- | Attempts to convert a string into
-readLength :: String -> Maybe Rational
+readLength :: T.Text -> Maybe Rational
 readLength s = do
   (n, unit) <- case (parse parseLength "" s) of
                   Left _ -> Nothing
@@ -164,24 +166,24 @@ readLength s = do
   (n *) <$> unitToMultiplier unit
 
 
-parseLength :: Parsec String () (Rational, String)
+parseLength :: Parsec T.Text () (Rational, T.Text)
 parseLength = do
     neg <- option "" ((:[]) <$> char '-')
     dec <- many1 digit
     frac <- option "" ((:) <$> char '.' <*> many1 digit)
     unit <- getInput
     -- This is safe as dec and frac must be a double of some kind
-    let [(n :: Double, [])] = reads (neg ++ dec ++ frac) :: [(Double, String)]
+    let [(n :: Double, [])] = reads (neg ++ dec ++ frac)
     return (round (n * 18) % 18, unit)
 
-textTypesMap :: M.Map TextType (String, String)
+textTypesMap :: M.Map TextType (T.Text, T.Text)
 textTypesMap = M.fromList textTypes
 
-revTextTypesMap :: M.Map String TextType
+revTextTypesMap :: M.Map T.Text TextType
 revTextTypesMap = M.fromList $ map (\(k, (v,_)) -> (v,k)) textTypes
 
 --TextType to (MathML, LaTeX)
-textTypes :: [(TextType, (String, String))]
+textTypes :: [(TextType, (T.Text, T.Text))]
 textTypes =
   [ ( TextNormal       , ("normal", "\\mathrm"))
   , ( TextBold         , ("bold", "\\mathbf"))
@@ -198,7 +200,7 @@ textTypes =
   , ( TextBoldFraktur         , ("bold-fraktur","\\mathbffrak"))
   , ( TextSansSerifItalic     , ("sans-serif-italic","\\mathsfit")) ]
 
-unicodeMath, base :: Set.Set String
+unicodeMath, base :: Set.Set T.Text
 unicodeMath = Set.fromList
   ["\\mathbfit", "\\mathbfsfup", "\\mathbfsfit", "\\mathbfscr",
    "\\mathbffrak", "\\mathsfit"]
@@ -206,7 +208,7 @@ base = Set.fromList
   ["\\mathbb", "\\mathrm", "\\mathbf", "\\mathit", "\\mathsf",
    "\\mathtt", "\\mathfrak", "\\mathcal"]
 
-alts :: M.Map String String
+alts :: M.Map T.Text T.Text
 alts = M.fromList
   [ ("\\mathbfit", "\\mathbf")
   , ("\\mathbfsfup", "\\mathbf")
@@ -216,14 +218,14 @@ alts = M.fromList
   , ("\\mathsfit", "\\mathsf")
   ]
 
-textPackage :: String -> [String] -> Bool
+textPackage :: T.Text -> [T.Text] -> Bool
 textPackage s e
   | s `Set.member` unicodeMath = "unicode-math" `elem` e
   | s `Set.member` base    = True
   | otherwise = True
 
 -- | Mapping between LaTeX scaling commands and the scaling factor
-scalers :: [(String, Rational)]
+scalers :: [(T.Text, Rational)]
 scalers =
           [ ("\\bigg", widthbigg)
           , ("\\Bigg", widthBigg)
@@ -263,31 +265,33 @@ getSpaceWidth _        = Nothing
 
 -- | Returns the sequence of unicode space characters closest to the
 -- specified width.
-getSpaceChars :: Rational -> [Char]
-getSpaceChars n =
-  case n of
-       _ | n < 0      -> "\x200B"  -- no negative space chars in unicode
-         | n <= 2/18  -> "\x200A"
-         | n <= 3/18  -> "\x2006"
-         | n <= 4/18  -> "\xA0"   -- could also be "\x2005"
-         | n <= 5/18  -> "\x2005"
-         | n <= 7/18  -> "\x2004"
-         | n <= 9/18  -> "\x2000"
-         | n < 1      -> '\x2000' : getSpaceChars (n - (1/2))
-         | n == 1     -> "\x2001"
-         | otherwise  -> '\x2001' : getSpaceChars (n - 1)
+getSpaceChars :: Rational -> T.Text
+getSpaceChars r
+  | n < 0 = "\x200B" -- no negative space chars in unicode
+  | otherwise = fracSpaces f <> emQuads n
+  where
+    (n, f) = properFraction r
+    emQuads x = T.replicate x "\x2001"
+    fracSpaces x
+      | x <= 2/18 = "\x200A"
+      | x <= 3/18 = "\x2006"
+      | x <= 4/18 = "\xA0"   -- could also be "\x2005"
+      | x <= 5/18 = "\x2005"
+      | x <= 7/18 = "\x2004"
+      | x <= 9/18 = "\x2000"
+      | otherwise = T.cons '\x2000' $ fracSpaces (x - (1/2))
 
 -- Accents which go under the character
-under :: [String]
+under :: [T.Text]
 under = ["\\underbrace", "\\underline", "\\underbar", "\\underbracket"]
 
 -- We want to parse these but we can't represent them in LaTeX
-unavailable :: [String]
+unavailable :: [T.Text]
 unavailable = ["\\overbracket", "\\underbracket"]
 
 
 -- | Mapping between unicode combining character and LaTeX accent command
-diacriticals :: [(String, String)]
+diacriticals :: [(T.Text, T.Text)]
 diacriticals =
                [ ("\x00B4", "\\acute")
                , ("\x0301", "\\acute")
@@ -329,7 +333,7 @@ diacriticals =
 
 
 -- Converts unit to multiplier to reach em
-unitToMultiplier :: String -> Maybe Rational
+unitToMultiplier :: T.Text -> Maybe Rational
 unitToMultiplier s = M.lookup s units
   where
     units = M.fromList  [ ( "pt" , 10)

--- a/src/Text/TeXMath/Types.hs
+++ b/src/Text/TeXMath/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, TypeSynonymInstances #-}
+{-# LANGUAGE DeriveDataTypeable, TypeSynonymInstances, OverloadedStrings #-}
 {-
 Copyright (C) 2009 John MacFarlane <jgm@berkeley.edu>
 
@@ -29,6 +29,7 @@ module Text.TeXMath.Types (Exp(..), TeXSymbolType(..), ArrayLine,
 where
 
 import Data.Generics
+import qualified Data.Text as T
 
 data TeXSymbolType = Ord | Op | Bin | Rel | Open | Close | Pun | Accent
                      | Fence | TOver | TUnder | Alpha | BotAccent | Rad
@@ -46,18 +47,18 @@ data FractionType = NormalFrac   -- ^ Displayed or textual, acc to 'DisplayType'
 type ArrayLine = [[Exp]]
 
 data Exp =
-    ENumber String  -- ^ A number (@\<mn\>@ in MathML).
+    ENumber T.Text  -- ^ A number (@\<mn\>@ in MathML).
   | EGrouped [Exp]  -- ^ A group of expressions that function as a unit
                     -- (e.g. @{...}@) in TeX, @\<mrow\>...\</mrow\>@ in MathML.
-  | EDelimited String String [InEDelimited] -- ^ A group of expressions inside
+  | EDelimited T.Text T.Text [InEDelimited] -- ^ A group of expressions inside
                     -- paired open and close delimiters (which may in some
                     -- cases be null).
-  | EIdentifier String  -- ^ An identifier, e.g. a variable (@\<mi\>...\</mi\>@
+  | EIdentifier T.Text  -- ^ An identifier, e.g. a variable (@\<mi\>...\</mi\>@
                     -- in MathML.  Note that MathML tends to use @\<mi\>@ tags
                     -- for "sin" and other mathematical operators; these
                     -- are represented as 'EMathOperator' in TeXMath.
-  | EMathOperator String  -- ^ A spelled-out operator like @lim@ or @sin@.
-  | ESymbol TeXSymbolType String  -- ^ A symbol.
+  | EMathOperator T.Text  -- ^ A spelled-out operator like @lim@ or @sin@.
+  | ESymbol TeXSymbolType T.Text  -- ^ A symbol.
   | ESpace Rational -- ^ A space, with the width specified in em.
   | ESub Exp Exp  -- ^ An expression with a subscript.  First argument is base,
                   -- second subscript.
@@ -88,7 +89,7 @@ data Exp =
                   -- specifies the alignments of the columns; the second gives
                   -- the contents of the lines.  All of these lists should be
                   -- the same length.
-  | EText TextType String  -- ^ Some normal text, possibly styled.
+  | EText TextType T.Text  -- ^ Some normal text, possibly styled.
   | EStyled TextType [Exp] -- ^  A group of styled expressions.
   deriving (Show, Read, Eq, Ord, Data, Typeable)
 
@@ -96,7 +97,7 @@ data Exp =
 -- (represented here as @Right@ values) or fences (represented here as
 -- @Left@, and in LaTeX using @\mid@).
 type InEDelimited = Either Middle Exp
-type Middle = String
+type Middle = T.Text
 
 data DisplayType = DisplayBlock  -- ^ A displayed formula.
                  | DisplayInline  -- ^ A formula rendered inline in text.
@@ -120,13 +121,13 @@ data TextType = TextNormal
 
 data FormType = FPrefix | FPostfix | FInfix deriving (Show, Ord, Eq)
 
-type Property = String
+type Property = T.Text
 
 -- | A record of the MathML dictionary as defined
 -- <http://www.w3.org/TR/MathML3/appendixc.html in the specification>
 data Operator = Operator
-                  { oper :: String -- ^ Operator
-                  , description :: String -- ^ Plain English Description
+                  { oper :: T.Text -- ^ Operator
+                  , description :: T.Text -- ^ Plain English Description
                   , form :: FormType -- ^ Whether Prefix, Postfix or Infix
                   , priority :: Int -- ^ Default priority for implicit
                                     --   nesting
@@ -141,16 +142,16 @@ data Operator = Operator
 -- <http://milde.users.sourceforge.net/LUCR/Math/data/unimathsymbols.txt
 -- here>
 data Record = Record { uchar :: Char -- ^ Unicode Character
-                     , commands :: [(String, String)] -- ^ LaTeX commands (package, command)
+                     , commands :: [(T.Text, T.Text)] -- ^ LaTeX commands (package, command)
                      , category :: TeXSymbolType -- ^ TeX math category
-                     , comments :: String -- ^ Plain english description
+                     , comments :: T.Text -- ^ Plain english description
                      } deriving (Show)
 
 data Position = Under | Over
 
 -- | List of available packages
-type Env = [String]
+type Env = [T.Text]
 
 -- | Contains @amsmath@ and @amssymbol@
-defaultEnv :: [String]
+defaultEnv :: [T.Text]
 defaultEnv = ["amsmath", "amssymb"]

--- a/src/Text/TeXMath/Unicode/Fonts.hs
+++ b/src/Text/TeXMath/Unicode/Fonts.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-
 Copyright (C) 2014 Matthew Pickering <matthewtpickering@gmail.com>
 
@@ -27,17 +28,18 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Utilities to convert between MS font codepoints and unicode characters.
 -}
-module Text.TeXMath.Unicode.Fonts (getUnicode, Font(..), stringToFont) where
+module Text.TeXMath.Unicode.Fonts (getUnicode, Font(..), textToFont) where
 import qualified Data.Map as M
+import qualified Data.Text as T
 
 -- | Enumeration of recognised fonts
 data Font = Symbol -- ^ <http://en.wikipedia.org/wiki/Symbol_(typeface) Adobe Symbol>
           deriving (Show, Eq)
 
 -- | Parse font name into Font if possible.
-stringToFont :: String -> Maybe Font
-stringToFont "Symbol" = Just Symbol
-stringToFont _ = Nothing
+textToFont :: T.Text -> Maybe Font
+textToFont "Symbol" = Just Symbol
+textToFont _ = Nothing
 
 -- | Given a font and codepoint, returns the corresponding unicode
 -- character

--- a/src/Text/TeXMath/Unicode/ToUnicode.hs
+++ b/src/Text/TeXMath/Unicode/ToUnicode.hs
@@ -27,15 +27,16 @@ where
 
 import Text.TeXMath.Types
 import qualified Data.Map as M
+import qualified Data.Text as T
 import Data.Maybe (fromMaybe)
 
 -- | Replace characters with their corresponding mathvariant unicode character.
 --  MathML has a mathvariant attribute which is unimplemented in Firefox
 --  (see <https://bugzilla.mozilla.org/show_bug.cgi?id=114365 here>)
 --  Therefore, we may want to translate mathscr, etc to unicode symbols directly.
-toUnicode :: TextType -> String -> String
+toUnicode :: TextType -> T.Text -> T.Text
 toUnicode TextNormal = id
-toUnicode tt = map (\c -> fromMaybe c (toUnicodeChar (tt, c)))
+toUnicode tt = T.map (\c -> fromMaybe c (toUnicodeChar (tt, c)))
 
 toUnicodeChar :: (TextType, Char) -> Maybe Char
 toUnicodeChar x = M.lookup x unicodeMap
@@ -46,11 +47,11 @@ fromUnicodeChar :: Char -> Maybe (TextType, Char)
 fromUnicodeChar c = M.lookup c reverseUnicodeMap
 
 -- | Inverse of 'toUnicode'.
-fromUnicode :: TextType -> String -> String
+fromUnicode :: TextType -> T.Text -> T.Text
 fromUnicode tt cs =
-  map (\c -> case fromUnicodeChar c of
-                   Just (tt', c') | tt' == tt -> c'
-                   _ -> c) cs
+  T.map (\c -> case fromUnicodeChar c of
+                 Just (tt', c') | tt' == tt -> c'
+                 _ -> c) cs
 
 reverseUnicodeMap :: M.Map Char (TextType, Char)
 reverseUnicodeMap = M.fromList $ map (\(a,b) -> (b,a)) unicodeTable

--- a/src/Text/TeXMath/Writers/Eqn.hs
+++ b/src/Text/TeXMath/Writers/Eqn.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, ViewPatterns, GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, ViewPatterns, GADTs, OverloadedStrings #-}
 {-
 Copyright (C) 2014 Matthew Pickering <matthewtpickering@gmail.com>
 
@@ -20,41 +20,43 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 module Text.TeXMath.Writers.Eqn (writeEqn) where
 
-import Data.List (intercalate, transpose)
+import Data.List (transpose)
 import Data.Char (isAscii, ord)
+import qualified Data.Text as T
 import Text.Printf (printf)
 import Text.TeXMath.Types
 import qualified Text.TeXMath.Shared as S
 import Data.Generics (everywhere, mkT)
 import Data.Ratio ((%))
+import Data.Semigroup ((<>))
 
 -- import Debug.Trace
 -- tr' x = trace (show x) x
 
 -- | Transforms an expression tree to equivalent Eqn with the default
 -- packages (amsmath and amssymb)
-writeEqn :: DisplayType -> [Exp] -> String
+writeEqn :: DisplayType -> [Exp] -> T.Text
 writeEqn dt exprs =
-  intercalate " " $ map writeExp $ everywhere (mkT $ S.handleDownup dt) exprs
+  T.intercalate " " $ map writeExp $ everywhere (mkT $ S.handleDownup dt) exprs
 
 -- like writeExp but inserts {} if contents contain a space
-writeExp' :: Exp -> String
+writeExp' :: Exp -> T.Text
 writeExp' e@(EGrouped _) = writeExp e
-writeExp' e = if ' ' `elem` s
-                 then "{" ++ s ++ "}"
+writeExp' e = if T.any (== ' ') s
+                 then "{" <> s <> "}"
                  else s
                where s = writeExp e
 
-writeExps :: [Exp] -> String
-writeExps = intercalate " " . map writeExp
+writeExps :: [Exp] -> T.Text
+writeExps = T.intercalate " " . map writeExp
 
-writeExp :: Exp -> String
+writeExp :: Exp -> T.Text
 writeExp (ENumber s) = s
-writeExp (EGrouped es) = "{" ++ writeExps es ++ "}"
+writeExp (EGrouped es) = "{" <> writeExps es <> "}"
 writeExp (EDelimited open close es) =
-  "left " ++ mbQuote open ++ " " ++ intercalate " " (map fromDelimited es) ++
-  " right " ++ mbQuote close
-  where fromDelimited (Left e)  = "\"" ++ e ++ "\""
+  "left " <> mbQuote open <> " " <> T.intercalate " " (map fromDelimited es) <>
+  " right " <> mbQuote close
+  where fromDelimited (Left e)  = "\"" <> e <> "\""
         fromDelimited (Right e) = writeExp e
         mbQuote "" = "\"\""
         mbQuote s  = s
@@ -63,8 +65,8 @@ writeExp (EMathOperator s) =
                "tanh", "arc", "max", "min", "lim",
                "log", "ln", "exp"]
      then s
-     else "\"" ++ s ++ "\""
-writeExp (ESymbol Ord [c])  -- do not render "invisible operators"
+     else "\"" <> s <> "\""
+writeExp (ESymbol Ord (T.unpack -> [c]))  -- do not render "invisible operators"
   | c `elem` ['\x2061'..'\x2064'] = "" -- see 3.2.5.5 of mathml spec
 writeExp (EIdentifier s) = writeExp (ESymbol Ord s)
 writeExp (ESymbol t s) =
@@ -129,19 +131,19 @@ writeExp (ESymbol t s) =
     "\958" -> "xi"
     "\926" -> "XI"
     "\950" -> "zeta"
-    _      -> let s' = if all isAscii s
+    _      -> let s' = if T.all isAscii s
                           then s
-                          else "\\[" ++ unwords (map toUchar s) ++ "]"
-                  toUchar c = printf "u%04X" (ord c)
-              in  if length s > 1 && (t == Rel || t == Bin || t == Op)
-                     then "roman{\"" ++
+                          else "\\[" <> T.unwords (map toUchar $ T.unpack s) <> "]"
+                  toUchar c = T.pack $ printf "u%04X" (ord c)
+              in  if T.length s > 1 && (t == Rel || t == Bin || t == Op)
+                     then "roman{\"" <>
                           (if t == Rel || t == Bin
                               then " "
-                              else "") ++
-                          s' ++
+                              else "") <>
+                          s' <>
                           (if t == Rel || t == Bin || t == Op
                               then " "
-                              else "") ++
+                              else "") <>
                           "\"}"
                      else s'
 
@@ -149,56 +151,58 @@ writeExp (ESpace d) =
   case d of
       _ | d > 0 && d < (2 % 9) -> "^"
         | d >= (2 % 9) && d < (3 % 9) -> "~"
-        | d < 0     -> "back " ++ show (floor (-1 * d * 100) :: Int)
-        | otherwise -> "fwd " ++ show (floor (d * 100) :: Int)
-writeExp (EFraction fractype e1 e2) = writeExp' e1 ++ op ++ writeExp' e2
+        | d < 0     -> "back " <> tshow (floor (-1 * d * 100) :: Int)
+        | otherwise -> "fwd " <> tshow (floor (d * 100) :: Int)
+writeExp (EFraction fractype e1 e2) = writeExp' e1 <> op <> writeExp' e2
   where op = if fractype == NoLineFrac
                 then " / "
                 else " over "
-writeExp (ESub b e1) = writeExp' b ++ " sub " ++ writeExp' e1
-writeExp (ESuper b e1) = writeExp' b ++ " sup " ++ writeExp' e1
+writeExp (ESub b e1) = writeExp' b <> " sub " <> writeExp' e1
+writeExp (ESuper b e1) = writeExp' b <> " sup " <> writeExp' e1
 writeExp (ESubsup b e1 e2) =
-  writeExp' b ++ " sub " ++ writeExp' e1 ++ " sup " ++ writeExp' e2
+  writeExp' b <> " sub " <> writeExp' e1 <> " sup " <> writeExp' e2
 writeExp (EOver _convertible b e1) =
-  writeExp' b ++ " to " ++ writeExp' e1
+  writeExp' b <> " to " <> writeExp' e1
 writeExp (EUnder _convertible b e1) =
-  writeExp' b ++ " from " ++ writeExp' e1
+  writeExp' b <> " from " <> writeExp' e1
 writeExp (EUnderover convertible b e1@(ESymbol Accent _) e2) =
   writeExp (EUnder convertible (EOver False b e2) e1)
 writeExp (EUnderover convertible b e1 e2@(ESymbol Accent _)) =
   writeExp (EOver convertible (EUnder False b e1) e2)
 writeExp (EUnderover _convertible b e1 e2) =
-  writeExp' b ++ " from " ++ writeExp' e1 ++ " to " ++ writeExp' e2
-writeExp (ESqrt e) = "sqrt " ++ writeExp' e
-writeExp (ERoot i e) = "\"\" sup " ++ writeExp' i ++ " sqrt " ++ writeExp' e
-writeExp (EPhantom e) = "hphantom " ++ writeExp' e
+  writeExp' b <> " from " <> writeExp' e1 <> " to " <> writeExp' e2
+writeExp (ESqrt e) = "sqrt " <> writeExp' e
+writeExp (ERoot i e) = "\"\" sup " <> writeExp' i <> " sqrt " <> writeExp' e
+writeExp (EPhantom e) = "hphantom " <> writeExp' e
 writeExp (EBoxed e) = writeExp e -- TODO: any way to do this?
 writeExp (EScaled _size e) = writeExp e -- TODO: any way?
 writeExp (EText ttype s) =
-  let quoted = "\"" ++ s ++ "\""
+  let quoted = "\"" <> s <> "\""
   in case ttype of
-       TextNormal -> "roman " ++ quoted
+       TextNormal -> "roman " <> quoted
        TextItalic -> quoted
-       TextBold   -> "bold " ++ quoted
-       TextBoldItalic -> "bold italic " ++ quoted
+       TextBold   -> "bold " <> quoted
+       TextBoldItalic -> "bold italic " <> quoted
        _   -> quoted
 writeExp (EStyled ttype es) =
-  let contents = "{" ++ writeExps es ++ "}"
+  let contents = "{" <> writeExps es <> "}"
   in case ttype of
-       TextNormal -> "roman " ++ contents
-       TextItalic -> "italic " ++ contents
-       TextBold   -> "bold " ++ contents
-       TextBoldItalic -> "bold italic " ++ contents
+       TextNormal -> "roman " <> contents
+       TextItalic -> "italic " <> contents
+       TextBold   -> "bold " <> contents
+       TextBoldItalic -> "bold italic " <> contents
        _   -> contents
 writeExp (EArray aligns rows) =
-  "matrix{\n" ++ concat cols ++ "}"
+  "matrix{\n" <> T.concat cols <> "}"
   where cols = zipWith tocol aligns (transpose rows)
         tocol al cs =
           (case al of
                AlignLeft -> "lcol"
                AlignCenter -> "ccol"
-               AlignRight -> "rcol") ++
-            "{ " ++ intercalate " above " (map tocell cs) ++ " }\n"
+               AlignRight -> "rcol") <>
+            "{ " <> T.intercalate " above " (map tocell cs) <> " }\n"
         tocell [e] = writeExp' e
         tocell es  = writeExp (EGrouped es)
 
+tshow :: Show a => a -> T.Text
+tshow = T.pack . show

--- a/src/Text/TeXMath/Writers/MathML.hs
+++ b/src/Text/TeXMath/Writers/MathML.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns, ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns, ScopedTypeVariables, OverloadedStrings #-}
 {-
 Copyright (C) 2009 John MacFarlane <jgm@berkeley.edu>
 
@@ -30,6 +30,8 @@ import Data.Generics (everywhere, mkT)
 import Text.TeXMath.Shared (getMMLType, handleDownup)
 import Text.TeXMath.Readers.MathML.MMLDict (getMathMLOperator)
 import Control.Applicative ((<$>))
+import Data.Semigroup ((<>))
+import qualified Data.Text as T
 import Text.Printf
 
 -- | Transforms an expression tree to a MathML XML tree
@@ -64,27 +66,30 @@ showFraction tt ft x y =
 spaceWidth :: Rational -> Element
 spaceWidth w =
   withAttribute "width" (dropTrailing0s
-     (printf "%.3f" (fromRational w :: Double)) ++ "em") $ unode "mspace" ()
+     (T.pack $ printf "%.3f" (fromRational w :: Double)) <> "em") $ unode "mspace" ()
 
 makeStretchy :: FormType -> Element -> Element
 makeStretchy (fromForm -> t)  = withAttribute "stretchy" "true"
                                 . withAttribute "form" t
 
-fromForm :: FormType -> String
+fromForm :: FormType -> T.Text
 fromForm FInfix   = "infix"
 fromForm FPostfix = "postfix"
 fromForm FPrefix  = "prefix"
 
-
 makeScaled :: Rational -> Element -> Element
 makeScaled x = withAttribute "minsize" s . withAttribute "maxsize" s
-  where s = dropTrailing0s $ printf "%.3f" (fromRational x :: Double)
+  where s = dropTrailing0s $ T.pack $ printf "%.3f" (fromRational x :: Double)
 
-dropTrailing0s :: String -> String
-dropTrailing0s = reverse . go . reverse
-  where go ('0':'.':xs) = '0':'.':xs
-        go ('0':xs) = go xs
-        go xs       = xs
+
+dropTrailing0s :: T.Text -> T.Text
+dropTrailing0s t = case T.unsnoc t of -- T.spanEnd does not exist
+  Just (ts, '0') -> addZero $ T.dropWhileEnd (== '0') ts
+  _              -> t
+  where
+    addZero x = case T.unsnoc x of
+      Just (_, '.') -> T.snoc x '0'
+      _ -> x
 
 makeStyled :: TextType -> [Element] -> Element
 makeStyled a es = withAttribute "mathvariant" attr
@@ -92,16 +97,20 @@ makeStyled a es = withAttribute "mathvariant" attr
   where attr = getMMLType a
 
 -- Note: Converts strings to unicode directly, as few renderers support those mathvariants.
-makeText :: TextType -> String -> Element
+makeText :: TextType -> T.Text -> Element
 makeText a s = case (leadingSp, trailingSp) of
                    (False, False) -> s'
                    (True,  False) -> mrow [sp, s']
                    (False, True)  -> mrow [s', sp]
                    (True,  True)  -> mrow [sp, s', sp]
   where sp = spaceWidth (1/3)
-        s' = withAttribute "mathvariant" attr $ unode "mtext" $ toUnicode a s
-        trailingSp = not (null s) && last s `elem` " \t"
-        leadingSp  = not (null s) && head s `elem` " \t"
+        s' = withAttribute "mathvariant" attr $ tunode "mtext" $ toUnicode a s
+        trailingSp = case T.unsnoc s of
+          Just (_, c) -> T.any (== c) " \t"
+          _           -> False
+        leadingSp  = case T.uncons s of
+          Just (c, _) -> T.any (== c) " \t"
+          _           -> False
         attr = getMMLType a
 
 makeArray :: TextType -> [Alignment] -> [ArrayLine] -> Element
@@ -113,12 +122,13 @@ makeArray tt as ls = unode "mtable" $
          setAlignment AlignCenter  = withAttribute "columnalign" "center"
          as'                       = as ++ cycle [AlignCenter]
 
-withAttribute :: String -> String -> Element -> Element
-withAttribute a = add_attr . Attr (unqual a)
+-- Kept as String for Text.XML.Light
+withAttribute :: String -> T.Text -> Element -> Element
+withAttribute a = add_attr . Attr (unqual a) . T.unpack
 
-accent :: String -> Element
+accent :: T.Text -> Element
 accent = add_attr (Attr (unqual "accent") "true") .
-           unode "mo"
+           tunode "mo"
 
 makeFence :: FormType -> Element -> Element
 makeFence (fromForm -> t) = withAttribute "stretchy" "false" . withAttribute "form" t
@@ -132,25 +142,25 @@ showExp' tt e =
                            getMathMLOperator x FPostfix of
                              Just True -> "true"
                              _         -> "false"
-      in  withAttribute "accent" isaccent $ unode "mo" x
+      in  withAttribute "accent" isaccent $ tunode "mo" x
     _                -> showExp tt e
 
 showExp :: TextType -> Exp -> Element
 showExp tt e =
  case e of
-   ENumber x        -> unode "mn" x
+   ENumber x        -> tunode "mn" x
    EGrouped [x]     -> showExp tt x
    EGrouped xs      -> mrow $ map (showExp tt) xs
    EDelimited start end xs -> mrow $
-                       [ makeStretchy FPrefix (unode "mo" start) | not (null start) ] ++
-                       map (either (makeStretchy FInfix . unode "mo") (showExp tt)) xs ++
-                       [ makeStretchy FPostfix (unode "mo" end) | not (null end) ]
-   EIdentifier x    -> unode "mi" $ toUnicode tt x
-   EMathOperator x  -> unode "mo" x
-   ESymbol Open x   -> makeFence FPrefix $ unode "mo" x
-   ESymbol Close x  -> makeFence FPostfix $ unode "mo" x
-   ESymbol Ord x    -> unode "mi" x
-   ESymbol _ x      -> unode "mo" x
+     [ makeStretchy FPrefix (tunode "mo" start) | not (T.null start) ] ++
+     map (either (makeStretchy FInfix . tunode "mo") (showExp tt)) xs ++
+     [ makeStretchy FPostfix (tunode "mo" end) | not (T.null end) ]
+   EIdentifier x    -> tunode "mi" $ toUnicode tt x
+   EMathOperator x  -> tunode "mo" x
+   ESymbol Open x   -> makeFence FPrefix $ tunode "mo" x
+   ESymbol Close x  -> makeFence FPostfix $ tunode "mo" x
+   ESymbol Ord x    -> tunode "mi" x
+   ESymbol _ x      -> tunode "mo" x
    ESpace x         -> spaceWidth x
    EFraction ft x y -> showFraction tt ft x y
    ESub x y         -> unode "msub" $ map (showExp tt) [x, y]
@@ -169,3 +179,7 @@ showExp tt e =
    EArray as ls     -> makeArray tt as ls
    EText a s        -> makeText a s
    EStyled a es     -> makeStyled a $ map (showExp a) es
+
+-- Kept as String for Text.XML.Light
+tunode :: String -> T.Text -> Element
+tunode s = unode s . T.unpack

--- a/src/Text/TeXMath/Writers/Pandoc.hs
+++ b/src/Text/TeXMath/Writers/Pandoc.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 {-
 Copyright (C) 2010-2013 John MacFarlane <jgm@berkeley.edu>
 
@@ -23,6 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 module Text.TeXMath.Writers.Pandoc (writePandoc)
 where
 import Text.Pandoc.Definition
+import qualified Data.Text as T
 import Text.TeXMath.Unicode.ToUnicode
 import Text.TeXMath.Types
 import Text.TeXMath.Shared (getSpaceChars)
@@ -69,7 +72,7 @@ thinspace = EText TextNormal "\x2006"
 medspace  = EText TextNormal "\x2005"
 widespace = EText TextNormal "\x2004"
 
-renderStr :: TextType -> String -> Inline
+renderStr :: TextType -> T.Text -> Inline
 renderStr tt s =
   case tt of
        TextNormal       -> Str s
@@ -116,29 +119,29 @@ expToInlines tt (ESubsup x y z) = do
   z' <- expToInlines tt z
   return $ x' ++ [Subscript y'] ++ [Superscript z']
 expToInlines _ (EText tt' x) = Just [renderStr tt' x]
-expToInlines tt (EOver b (EGrouped [EIdentifier [c]]) (ESymbol Accent [accent])) = expToInlines tt (EOver b (EIdentifier [c]) (ESymbol Accent [accent]))
-expToInlines tt (EOver _ (EIdentifier [c]) (ESymbol Accent [accent])) =
+expToInlines tt (EOver b (EGrouped [EIdentifier (T.unpack -> [c])]) (ESymbol Accent (T.unpack -> [accent]))) = expToInlines tt (EOver b (EIdentifier $ T.singleton c) (ESymbol Accent $ T.singleton accent))
+expToInlines tt (EOver _ (EIdentifier (T.unpack -> [c])) (ESymbol Accent (T.unpack -> [accent]))) =
     case accent of
-         '\x203E' -> Just [renderStr tt' [c,'\x0304']]  -- bar
-         '\x0304' -> Just [renderStr tt' [c,'\x0304']]  -- bar combining
-         '\x00B4' -> Just [renderStr tt' [c,'\x0301']]  -- acute
-         '\x0301' -> Just [renderStr tt' [c,'\x0301']]  -- acute combining
-         '\x0060' -> Just [renderStr tt' [c,'\x0300']]  -- grave
-         '\x0300' -> Just [renderStr tt' [c,'\x0300']]  -- grave combining
-         '\x02D8' -> Just [renderStr tt' [c,'\x0306']]  -- breve
-         '\x0306' -> Just [renderStr tt' [c,'\x0306']]  -- breve combining
-         '\x02C7' -> Just [renderStr tt' [c,'\x030C']]  -- check
-         '\x030C' -> Just [renderStr tt' [c,'\x030C']]  -- check combining
-         '.'      -> Just [renderStr tt' [c,'\x0307']]  -- dot
-         '\x0307' -> Just [renderStr tt' [c,'\x0307']]  -- dot combining
-         '\x00B0' -> Just [renderStr tt' [c,'\x030A']]  -- ring
-         '\x030A' -> Just [renderStr tt' [c,'\x030A']]  -- ring combining
-         '\x20D7' -> Just [renderStr tt' [c,'\x20D7']]  -- arrow right
-         '\x20D6' -> Just [renderStr tt' [c,'\x20D6']]  -- arrow left
-         '\x005E' -> Just [renderStr tt' [c,'\x0302']]  -- hat
-         '\x0302' -> Just [renderStr tt' [c,'\x0302']]  -- hat combining
-         '~'      -> Just [renderStr tt' [c,'\x0303']]  -- tilde
-         '\x0303' -> Just [renderStr tt' [c,'\x0303']]  -- tilde combining
+         '\x203E' -> Just [renderStr tt' $ T.pack [c,'\x0304']]  -- bar
+         '\x0304' -> Just [renderStr tt' $ T.pack [c,'\x0304']]  -- bar combining
+         '\x00B4' -> Just [renderStr tt' $ T.pack [c,'\x0301']]  -- acute
+         '\x0301' -> Just [renderStr tt' $ T.pack [c,'\x0301']]  -- acute combining
+         '\x0060' -> Just [renderStr tt' $ T.pack [c,'\x0300']]  -- grave
+         '\x0300' -> Just [renderStr tt' $ T.pack [c,'\x0300']]  -- grave combining
+         '\x02D8' -> Just [renderStr tt' $ T.pack [c,'\x0306']]  -- breve
+         '\x0306' -> Just [renderStr tt' $ T.pack [c,'\x0306']]  -- breve combining
+         '\x02C7' -> Just [renderStr tt' $ T.pack [c,'\x030C']]  -- check
+         '\x030C' -> Just [renderStr tt' $ T.pack [c,'\x030C']]  -- check combining
+         '.'      -> Just [renderStr tt' $ T.pack [c,'\x0307']]  -- dot
+         '\x0307' -> Just [renderStr tt' $ T.pack [c,'\x0307']]  -- dot combining
+         '\x00B0' -> Just [renderStr tt' $ T.pack [c,'\x030A']]  -- ring
+         '\x030A' -> Just [renderStr tt' $ T.pack [c,'\x030A']]  -- ring combining
+         '\x20D7' -> Just [renderStr tt' $ T.pack [c,'\x20D7']]  -- arrow right
+         '\x20D6' -> Just [renderStr tt' $ T.pack [c,'\x20D6']]  -- arrow left
+         '\x005E' -> Just [renderStr tt' $ T.pack [c,'\x0302']]  -- hat
+         '\x0302' -> Just [renderStr tt' $ T.pack [c,'\x0302']]  -- hat combining
+         '~'      -> Just [renderStr tt' $ T.pack [c,'\x0303']]  -- tilde
+         '\x0303' -> Just [renderStr tt' $ T.pack [c,'\x0303']]  -- tilde combining
          _        -> Nothing
       where tt' = if tt == TextNormal then TextItalic else tt
 expToInlines tt (EScaled _ e) = expToInlines tt e

--- a/src/Text/TeXMath/Writers/TeX.hs
+++ b/src/Text/TeXMath/Writers/TeX.hs
@@ -52,9 +52,15 @@ addLaTeXEnvironment dt math =
 -- |  Transforms an expression tree to equivalent LaTeX with the specified
 -- packages
 writeTeXWith :: Env -> [Exp] -> T.Text
-writeTeXWith env es = T.drop 1 . T.init . flip renderTeX "" . Grouped $
+writeTeXWith env es = stripFirstLast . flip renderTeX "" . Grouped $
                             runExpr env $
                               mapM_ writeExp (removeOuterGroup es)
+  where
+    stripFirstLast t = case T.uncons t of
+      Just (_, t') -> case T.unsnoc t' of
+        Just (t'', _) -> t''
+        _             -> t'
+      _               -> ""
 
 runExpr :: Env -> Math () -> [TeX]
 runExpr e m = flip runReader (MathState e False) $ execWriterT (runTeXMath m)

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,8 @@ flags:
     executable: true
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+  # The text branch
+- git: https://github.com/jgm/pandoc-types
+  commit: f63baa73ae9a353b1896b008a145ebf1ef9a0342
 resolver: lts-13.5

--- a/tests/test-texmath.hs
+++ b/tests/test-texmath.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 import System.Directory
 import System.FilePath
 import Text.XML.Light
@@ -6,18 +8,15 @@ import System.IO.Temp (withTempDirectory)
 import System.Process
 import Text.TeXMath
 import System.Exit
-import Control.Applicative
 import Control.Monad
+import Data.Semigroup ((<>))
 import GHC.IO.Encoding (setLocaleEncoding)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Data.List (intercalate)
-import Data.List.Split (splitWhen)
 import System.Environment (getArgs)
 
--- strict version of readFile
-readFile' :: FilePath -> IO String
-readFile' f = T.unpack <$> T.readFile f
+tshow :: Show a => a -> T.Text
+tshow = T.pack . show
 
 data Status = Pass FilePath FilePath
             | Fail FilePath FilePath
@@ -26,16 +25,16 @@ data Status = Pass FilePath FilePath
 
 type Ext = String
 
-readers :: [(Ext, String -> Either String [Exp])]
+readers :: [(Ext, T.Text -> Either T.Text [Exp])]
 readers = [ (".tex", readTeX)
           , (".mml", readMathML)
           , (".omml", readOMML)
           ]
 
-writers :: [(Ext, [Exp] -> String)]
-writers = [ (".mml", ppTopElement . writeMathML DisplayBlock)
+writers :: [(Ext, [Exp] -> T.Text)]
+writers = [ (".mml", T.pack . ppTopElement . writeMathML DisplayBlock)
           , (".tex", writeTeX)
-          , (".omml", ppTopElement . writeOMML DisplayBlock)
+          , (".omml", T.pack . ppTopElement . writeOMML DisplayBlock)
           , (".eqn", writeEqn DisplayBlock)
           ]
 
@@ -52,16 +51,16 @@ main = do
                  then do
                    texs <- runRoundTrip "tex" writeTeX readTeX
                    ommls <- runRoundTrip "omml"
-                               (ppTopElement .  writeOMML DisplayBlock) readOMML
+                               (T.pack . ppTopElement .  writeOMML DisplayBlock) readOMML
                    mathmls <- runRoundTrip "mml"
-                                (ppTopElement . writeMathML DisplayBlock)
+                                (T.pack . ppTopElement . writeMathML DisplayBlock)
                                 readMathML
-                   return $ texs ++ ommls ++ mathmls
-                 else (++) <$> (concat <$> mapM (uncurry (runReader regen)) readers)
+                   return $ texs <> ommls <> mathmls
+                 else (<>) <$> (concat <$> mapM (uncurry (runReader regen)) readers)
                            <*> (concat <$> mapM (uncurry (runWriter regen)) writers)
   let passes = length $ filter isPass statuses
   let failures = length statuses - passes
-  putStrLn $ show passes ++ " tests passed, " ++ show failures ++ " failed."
+  T.putStrLn $ tshow passes <> " tests passed, " <> tshow failures <> " failed."
   if all isPass statuses
      then exitWith ExitSuccess
      else exitWith $ ExitFailure failures
@@ -70,47 +69,49 @@ printPass :: FilePath -> FilePath -> IO ()
 printPass _inp _out = return () -- putStrLn $ "PASSED:  " ++ inp ++ " ==> " ++ out
 
 -- Second parameter is Left format (for round-trip) or Right output file.
-printFail :: FilePath -> Either String FilePath -> String -> IO ()
+printFail :: FilePath -> Either T.Text FilePath -> T.Text -> IO ()
 printFail inp out actual =
   withTempDirectory "." ((either (const inp) id out) ++ ".") $ \tmpDir -> do
     -- break native files at commas for easier diffing
     let breakAtCommas = case out of
-                             Left _ -> intercalate ",\n" . splitWhen (==',')
+                             Left _ -> T.intercalate ",\n" . T.split (==',')
                              Right f | takeExtension f == ".native" ->
-                                       intercalate ",\n" . splitWhen (==',')
+                                       T.intercalate ",\n" . T.split (==',')
                              _ -> id
-    putStrLn $ "FAILED:  " ++ inp ++ " ==> " ++
-              either (\x -> "round trip via " ++ x) id out
-    readFile' (either (const inp) id out) >>=
-      writeFile (tmpDir </> "expected") . ensureFinalNewline . breakAtCommas
-    writeFile (tmpDir </> "actual") $ ensureFinalNewline $ breakAtCommas actual
+    T.putStrLn $ "FAILED:  " <> T.pack inp <> " ==> " <>
+      either (\x -> "round trip via " <> x) T.pack out
+    T.readFile (either (const inp) id out) >>=
+      T.writeFile (tmpDir </> "expected") . ensureFinalNewline . breakAtCommas
+    T.writeFile (tmpDir </> "actual") $ ensureFinalNewline $ breakAtCommas actual
     hFlush stdout
     _ <- runProcess "diff" ["-u", tmpDir </> "expected", tmpDir </> "actual"]
              Nothing Nothing Nothing Nothing Nothing >>= waitForProcess
     putStrLn ""
 
-printError :: FilePath -> FilePath -> String -> IO ()
+printError :: FilePath -> FilePath -> T.Text -> IO ()
 printError inp out msg =
-  putStrLn $ "ERROR:  " ++ inp ++ " ==> " ++ out ++ "\n" ++ msg
+  T.putStrLn $ "ERROR:  " <> T.pack inp <> " ==> " <> T.pack out <> "\n" <> msg
 
-ensureFinalNewline :: String -> String
-ensureFinalNewline "" = ""
-ensureFinalNewline xs = if last xs == '\n' then xs else xs ++ "\n"
+ensureFinalNewline :: T.Text -> T.Text
+ensureFinalNewline xs = case T.unsnoc xs of
+  Nothing        -> xs
+  Just (_, '\n') -> xs
+  _              -> xs <> "\n"
 
 isPass :: Status -> Bool
 isPass (Pass _ _) = True
 isPass _ = False
 
-runReader :: Bool -> String -> (String -> Either String [Exp]) -> IO [Status]
+runReader :: Bool -> Ext -> (T.Text -> Either T.Text [Exp]) -> IO [Status]
 runReader regen ext f = do
   input <- filter (\x -> takeExtension x == ext) <$> getDirectoryContents "./src"
   let input' = map ("src" </>) input
   mapM (\inp ->
-        runReaderTest regen (\x -> show <$> f x) inp (rename inp)) input'
+        runReaderTest regen (\x -> tshow <$> f x) inp (rename inp)) input'
   where
     rename x = replaceExtension (replaceDirectory x ("./readers" </> (tail ext))) "native"
 
-runWriter ::  Bool -> String -> ([Exp] -> String) -> IO [Status]
+runWriter :: Bool -> Ext -> ([Exp] -> T.Text) -> IO [Status]
 runWriter regen ext f = do
   mmls <- map ("./readers/mml/"++) <$> getDirectoryContents "./readers/mml"
   texs <- map ("./readers/tex/"++) <$> getDirectoryContents "./readers/tex"
@@ -121,35 +122,35 @@ runWriter regen ext f = do
        inputs
 
 runRoundTrip :: String
-             -> ([Exp] -> String)
-             -> (String -> Either String [Exp])
+             -> ([Exp] -> T.Text)
+             -> (T.Text -> Either T.Text [Exp])
              -> IO [Status]
 runRoundTrip fmt writer reader = do
   inps <- filter (\x -> takeExtension x == ".native") <$>
-             map (("./readers/" ++ fmt ++ "/") ++) <$>
-                 getDirectoryContents ("./readers/" ++ fmt)
+             map (("./readers/" <> fmt <> "/") <>) <$>
+                 getDirectoryContents ("./readers/" <> fmt)
   mapM (runRoundTripTest fmt writer reader) inps
 
-runWriterTest :: Bool -> ([Exp] -> String) -> FilePath -> FilePath -> IO Status
+runWriterTest :: Bool -> ([Exp] -> T.Text) -> FilePath -> FilePath -> IO Status
 runWriterTest regen f input output = do
-  rawnative <- readFile' input
-  native <- case reads rawnative of
+  rawnative <- T.readFile input
+  native <- case reads $ T.unpack rawnative of
                  ((x,_):_) -> return x
                  []        -> error $ "Could not read " ++ input
   let result = ensureFinalNewline $ f native
-  when regen $ writeFile output result
-  out_t <- ensureFinalNewline <$> readFile' output
+  when regen $ T.writeFile output result
+  out_t <- ensureFinalNewline <$> T.readFile output
   if result == out_t
      then printPass input output >> return (Pass input output)
      else printFail input (Right output) result >> return (Fail input output)
 
 runReaderTest :: Bool
-        -> (String -> Either String String)
+        -> (T.Text -> Either T.Text T.Text)
         -> FilePath
         -> FilePath
         -> IO Status
 runReaderTest regen fn input output = do
-  inp_t <- readFile' input
+  inp_t <- T.readFile input
   let result = ensureFinalNewline <$> fn inp_t
   let errfile = dropExtension output ++ ".error"
   errorExpected <- doesFileExist errfile
@@ -164,8 +165,8 @@ runReaderTest regen fn input output = do
              return (Error input errfile)
      else do
        when regen $
-         writeFile output (either (const "") id result)
-       out_t <- ensureFinalNewline <$> readFile' output
+         T.writeFile output (either (const "") id result)
+       out_t <- ensureFinalNewline <$> T.readFile output
        case result of
             Left msg -> do
                 printError input output msg
@@ -179,13 +180,13 @@ runReaderTest regen fn input output = do
                   return (Fail input output)
 
 runRoundTripTest :: String
-                 -> ([Exp] -> String)
-                 -> (String -> Either String [Exp])
+                 -> ([Exp] -> T.Text)
+                 -> (T.Text -> Either T.Text [Exp])
                  -> FilePath
                  -> IO Status
 runRoundTripTest fmt writer reader input = do
-  rawnative <- readFile' input
-  native <- case reads rawnative of
+  rawnative <- T.readFile input
+  native <- case reads $ T.unpack rawnative of
                  ((x,_):_) -> return x
                  []        -> error $ "Could not read " ++ input
   let rendered = ensureFinalNewline $ writer native
@@ -195,5 +196,5 @@ runRoundTripTest fmt writer reader input = do
        Right r
          | r == native -> printPass input input >>
                           return (Pass input input)
-         | otherwise   -> printFail input (Left fmt) (show r) >>
+         | otherwise   -> printFail input (Left $ T.pack fmt) (tshow r) >>
                           return (Fail input input)

--- a/texmath.cabal
+++ b/texmath.cabal
@@ -87,7 +87,7 @@ Flag network-uri
 
 Library
     Build-depends:       base >= 4.8 && < 5, syb >= 0.4.2 && < 0.8, xml, parsec >= 3, containers,
-                         pandoc-types >= 1.12.3.3 && < 1.18, mtl
+                         pandoc-types >= 1.12.3.3 && < 1.18, mtl, text
     
     Exposed-modules:     Text.TeXMath,
                          Text.TeXMath.Types,
@@ -131,7 +131,7 @@ Executable texmath
       Buildable:         True
       Build-Depends:     base >= 4.8 && < 5, texmath, xml,
                          pandoc-types >= 1.12.3.3 && < 1.18,
-                         split, aeson, bytestring, text
+                         aeson, bytestring, text
     else
       Buildable:         False
     if flag(network-uri)
@@ -145,6 +145,6 @@ Test-Suite test-texmath
     Hs-Source-Dirs:      tests
     Build-Depends:       base >= 4.8 && < 5, process, directory, filepath,
                          texmath, xml, utf8-string, bytestring, process,
-                         temporary, text, split
+                         temporary, text
     Default-Language:    Haskell2010
     Ghc-Options:         -Wall


### PR DESCRIPTION
The switch is largely complete. A few notes:

- Each public type now uses `Text` instead of `String`, and the `extras/texmath.hs` and `tests/test-texmath.hs` files use `Text` as much as possible.
- All of the common modules use `Text` exclusively.
- Certain internal functions in the readers and writers still take or emit `String` values, because they are written with `parsec` parsers (that naturally return strings) or because they use functions in `xml` (whose types use `String`).
- `stack.yaml` currently points to the `text` branch in `pandoc-types`.
- In a few places in the readers and writers, code like
  ```
  case T.unpack t of
    [x, y] -> ...
    _      -> (things involving t)
  ```
  still occurs, both in that form and with `ViewPatterns`. I have left it like that for now, but I am not sure of the performance implications of it.
- The dependency on `split` is now unnecessary and was removed.
- The documentation in `Text.TeXMath` has been updated with the new types.
- The code in `lib` (that I assume is responsible for generating some of the contents of the files) has not been changed.