### PR TITLE
Fix compilation with GHC-9.0.1

### DIFF
--- a/src/Text/TeXMath/Readers/TeX/Macros.hs
+++ b/src/Text/TeXMath/Readers/TeX/Macros.hs
@@ -103,7 +103,7 @@ applyMacrosOnce ms s =
        Left _  -> Nothing
     where tok = try $ do
                   skipComment
-                  choice [ choice (map macroParser ms)
+                  choice [ choice (map (\m -> macroParser m) ms)
                          , T.pack <$> ctrlseq
                          , T.pack <$> count 1 anyChar ]
 


### PR DESCRIPTION
Fixes #169.

Background:
https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption