### PR TITLE
Also ignore stared version of `\tag`

### DIFF
--- a/src/Text/TeXMath/Readers/TeX.hs
+++ b/src/Text/TeXMath/Readers/TeX.hs
@@ -151,7 +151,7 @@ label :: TP ()
 label = ctrlseq "label" *> braces (skipMany (noneOf "}"))
 
 tag :: TP ()
-tag = ctrlseq "tag" *> braces (skipMany (noneOf "}"))
+tag = ctrlseq "tag" *> optional (char '*') *> braces (skipMany (noneOf "}"))
 
 unGrouped :: Exp -> [Exp]
 unGrouped (EGrouped xs) = xs


### PR DESCRIPTION
The amsmath manual states

> There is also a `\tag*` command that causes the text you supply to be
> typeset literally, without adding parentheses around it.

The command is ignored, just like `\tag`.