### PR TITLE
TeX reader: Improve angled-brackets support.

### DIFF
--- a/src/Text/TeXMath/Readers/TeX.hs
+++ b/src/Text/TeXMath/Readers/TeX.hs
@@ -355,7 +355,12 @@ basicEnclosure = try $ do
 fence :: String -> TP Text
 fence cmd = do
   symbol cmd
-  enc <- basicEnclosure <|> (try (symbol ".") >> return (ESymbol Open ""))
+  let nullDelim = try (ESymbol Open "" <$ symbol ".")
+      angleDelim = try $ choice
+        [ ESymbol Open "\x27E8" <$ symbol "<"
+        , ESymbol Close "\x27E9" <$ symbol ">"
+        ]
+  enc <- basicEnclosure <|> nullDelim <|> angleDelim
   case enc of
        ESymbol Open x  -> return x
        ESymbol Close x -> return x

--- a/src/Text/TeXMath/Readers/TeX.hs
+++ b/src/Text/TeXMath/Readers/TeX.hs
@@ -32,7 +32,7 @@ import Data.Char (isDigit, isAscii, isLetter)
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Data.Text (Text)
-import Data.Maybe (mapMaybe, catMaybes)
+import Data.Maybe (catMaybes, fromJust, mapMaybe)
 import Data.Semigroup ((<>))
 import Text.Parsec hiding (label)
 import Text.Parsec.Error
@@ -43,7 +43,6 @@ import Control.Applicative ((<*), (*>), (<*>), (<$>), (<$), pure)
 import qualified Text.TeXMath.Shared as S
 import Text.TeXMath.Readers.TeX.Macros (applyMacros, parseMacroDefinitions)
 import Text.TeXMath.Unicode.ToTeX (getSymbolType)
-import Data.Maybe (fromJust)
 import Text.TeXMath.Unicode.ToUnicode (toUnicode)
 import Text.TeXMath.Shared (getSpaceChars)
 import Data.Generics (everywhere, mkT)

--- a/tests/src/schwinger_dyson.tex
+++ b/tests/src/schwinger_dyson.tex
@@ -1,1 +1,1 @@
-   \left\langle\psi\left|\mathcal{T}\left\{\frac{\delta}{\delta\phi}F[\phi]\right\}\right|\psi\right\rangle = -\mathrm{i}\left\langle\psi\left|\mathcal{T}\left\{F[\phi]\frac{\delta}{\delta\phi}S[\phi]\right\}\right|\psi\right\rangle
+   \left\langle\psi\left|\mathcal{T}\left\{\frac{\delta}{\delta\phi}F[\phi]\right\}\right|\psi\right\rangle = -\mathrm{i}\left<\psi\left|\mathcal{T}\left\{F[\phi]\frac{\delta}{\delta\phi}S[\phi]\right\}\right|\psi\right>


### PR DESCRIPTION
The amsmath package allows `\left<` and `\right>` as alternatives to
`\left\langle` and `\right\rangle`, respectively.