### PR TITLE
OMML Reader: set the default value of pos to "bot".

### DIFF
--- a/src/Text/TeXMath/Readers/OMML.hs
+++ b/src/Text/TeXMath/Readers/OMML.hs
@@ -255,10 +255,11 @@ elemToExps' element | isElem "m" "bar" element = do
             findAttrBy (hasElemName "m" "val")
   baseExp <- filterChildName (hasElemName "m" "e") element >>=
              elemToBase
+  -- According to OMML Specification, the default value of pos (whether it exists or not) is "bot"
+  -- see https://github.com/jgm/texmath/issues/187
   case pos of
     "top" -> Just [EOver False baseExp (ESymbol TOver "\773")]
-    "bot" -> Just [EUnder False baseExp (ESymbol TUnder "\818")]
-    _     -> Nothing
+    _     -> Just [EUnder False baseExp (ESymbol TUnder "\818")]
 elemToExps' element | isElem "m" "box" element = do
   baseExp <- filterChildName (hasElemName "m" "e") element >>=
              elemToBase


### PR DESCRIPTION
closes #187 This is according to the spec and matches the already implemented
behaviour in line 337.