### PR TITLE
OOML Writer: Add low line char ("_") to `isBarChar`

### DIFF
--- a/src/Text/TeXMath/Writers/OMML.hs
+++ b/src/Text/TeXMath/Writers/OMML.hs
@@ -297,7 +297,8 @@ showExp props e =
 
 isBarChar :: Char -> Bool
 isBarChar c = c == '\x203E' || c == '\x00AF' ||
-              c == '\x0304' || c == '\x0333'
+              c == '\x0304' || c == '\x0333' ||
+              c == '_'
 
 -- | Checks whether an expression marks the start of an nary operator
 -- expression. These are different integrals, sums, products, and

--- a/test/writer/omml/subsup.test
+++ b/test/writer/omml/subsup.test
@@ -247,21 +247,16 @@
     </m:r>
     <m:sSubSup>
       <m:e>
-        <m:limLow>
+        <m:bar>
+          <m:barPr>
+            <m:pos m:val="bot" />
+          </m:barPr>
           <m:e>
             <m:r>
               <m:t>u</m:t>
             </m:r>
           </m:e>
-          <m:lim>
-            <m:r>
-              <m:rPr>
-                <m:sty m:val="p" />
-              </m:rPr>
-              <m:t>_</m:t>
-            </m:r>
-          </m:lim>
-        </m:limLow>
+        </m:bar>
       </m:e>
       <m:sub>
         <m:r>


### PR DESCRIPTION
"\_" is used for `\underline` in `symbolMapOverrides`. "_" should be regarded
as bar char, or `\underline{xxx}` will be written as `\underset{\_}{xxx}`
in OOML.

Fix jgm/pandoc#8152