### PR TITLE
Typst Writer: several fixes

### DIFF
--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -139,6 +139,7 @@ writeExp (EOver _convertible b e1) =
     ESymbol Accent "\x2c7" -> "caron" <> inParens (writeExp b)
     ESymbol Accent "\x2192" -> "->" <> inParens (writeExp b)
     ESymbol Accent "\x2190" -> "<-" <> inParens (writeExp b)
+    ESymbol Accent "\8407" -> "arrow" <> inParens (writeExp b)
     ESymbol TOver "\9182" -> "overbrace(" <> writeExp b <> ")"
     ESymbol TOver "\9140" -> "overbracket(" <> writeExp b <> ")"
     ESymbol TOver "\175" -> "overline(" <> writeExp b <> ")"

--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -252,9 +252,9 @@ mkArray rows =
  where
    mkRow = T.intercalate ", " . mkCells . map mkCell
    mkCells cs =
-    if length cs <= 1 || head cs /= ""
-      then cs
-      else "#none" : tail cs
+     case cs of
+       ("":rest) -> "#none" : rest
+       _ -> cs
    mkCell = writeExps
 
 tshow :: Show a => a -> Text

--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -250,7 +250,11 @@ mkArray :: [[[Exp]]] -> Text
 mkArray rows =
   T.intercalate "; " $ map mkRow rows
  where
-   mkRow = T.intercalate ", " . map mkCell
+   mkRow = T.intercalate ", " . mkCells . map mkCell
+   mkCells cs =
+    if length cs <= 1 || head cs /= ""
+      then cs
+      else "#none" : tail cs
    mkCell = writeExps
 
 tshow :: Show a => a -> Text

--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -45,7 +45,7 @@ inParens :: Text -> Text
 inParens s = "(" <> s <> ")"
 
 inQuotes :: Text -> Text
-inQuotes s = "\"" <> s <> "\""
+inQuotes s = "\"" <> escInQuotes s <> "\""
 
 esc :: Text -> Text
 esc t =
@@ -65,6 +65,16 @@ esc t =
     needsEscape ')' = True
     needsEscape '_' = True
     needsEscape _ = False
+
+escInQuotes :: Text -> Text
+escInQuotes t =
+  if T.any (== '"') t
+    then T.concatMap escapeChar t
+    else t
+  where
+    escapeChar c
+      | c == '"' = "\\" <> T.singleton c
+      | otherwise = T.singleton c
 
 writeExpS :: Exp -> Text
 writeExpS (EGrouped es) = "(" <> writeExps es <> ")"

--- a/test/writer/typst/divergence.test
+++ b/test/writer/typst/divergence.test
@@ -22,4 +22,4 @@
     (EGrouped [ ESymbol Ord "\8706" , EIdentifier "z" ])
 ]
 >>> typst
-nabla dot.op v^(⃗) eq frac(diff v_x, diff x) plus frac(diff v_y, diff y) plus frac(diff v_z, diff z)
+nabla dot.op arrow(v) eq frac(diff v_x, diff x) plus frac(diff v_y, diff y) plus frac(diff v_z, diff z)


### PR DESCRIPTION
**Additional information**
1ceec56445cc4d7ee0e2fbf68e04ee887a6d5eb4 Matrices with blank elements at the start of its rows (e.g. below) would fail to compile by Typst. This is solved by writing `#none` to each row's head (if empty) instead of leaving it as-is.
![image](https://github.com/jgm/texmath/assets/20639794/5b1dbe24-1f0a-446c-9968-5441abe91e3f)
