### PR TITLE
Fix issue #264 by formatting maxsize and minsize as percentages 

### DIFF
--- a/src/Text/TeXMath/Writers/MathML.hs
+++ b/src/Text/TeXMath/Writers/MathML.hs
@@ -80,8 +80,9 @@ fromForm FPostfix = "postfix"
 fromForm FPrefix  = "prefix"
 
 makeScaled :: Rational -> Element -> Element
-makeScaled x = withAttribute "minsize" s . withAttribute "maxsize" s
-  where s = dropTrailing0s $ T.pack $ printf "%.3f" (fromRational x :: Double)
+makeScaled x = withAttribute "minsize" p . withAttribute "maxsize" p 
+               . setAttribute "stretchy" "true"
+  where p = T.pack $ printf "%d%%" (round (100*x) :: Int)
 
 
 dropTrailing0s :: T.Text -> T.Text
@@ -136,6 +137,18 @@ makeArray tt as ls = unode "mtable" $
 withAttribute :: String -> T.Text -> Element -> Element
 withAttribute a = add_attr . Attr (unqual a) . T.unpack
 
+-- Preserves the order of any existing attributes
+setAttribute :: String -> T.Text -> Element -> Element
+setAttribute a v e = e { elAttribs = update (elAttribs e) }
+  where
+    newAttr = Attr (unqual a) (T.unpack v)
+    update [] = [newAttr]
+    update (x:xs)
+        | qName (attrKey x) == a = 
+            newAttr : xs
+        | otherwise = 
+            x : update xs
+            
 accent :: T.Text -> Element
 accent = add_attr (Attr (unqual "accent") "true") .
            tunode "mo"

--- a/test/regression/264.test
+++ b/test/regression/264.test
@@ -1,0 +1,82 @@
+<<< native
+[ ESymbol Op "\8707"
+, EIdentifier "x"
+, ESymbol Op "\8704"
+, EIdentifier "y"
+, ESymbol Op "\8704"
+, EIdentifier "z"
+, EScaled (9 % 5) (ESymbol Open "(")
+, EScaled (6 % 5) (ESymbol Open "(")
+, EIdentifier "F"
+, ESymbol Open "("
+, EIdentifier "x"
+, ESymbol Pun ","
+, EIdentifier "y"
+, ESymbol Close ")"
+, ESymbol Bin "\8743"
+, EIdentifier "F"
+, ESymbol Open "("
+, EIdentifier "x"
+, ESymbol Pun ","
+, EIdentifier "z"
+, ESymbol Close ")"
+, ESymbol Bin "\8743"
+, ESymbol Open "("
+, EIdentifier "y"
+, ESymbol Rel "\8800"
+, EIdentifier "z"
+, ESymbol Close ")"
+, EScaled (6 % 5) (ESymbol Close ")")
+, ESymbol Rel "\8594"
+, ESymbol Op "\172"
+, EIdentifier "F"
+, ESymbol Open "("
+, EIdentifier "y"
+, ESymbol Pun ","
+, EIdentifier "z"
+, ESymbol Close ")"
+, EScaled (9 % 5) (ESymbol Close ")")
+]
+>>> mml
+<?xml version='1.0' ?>
+<math display="block" xmlns="http://www.w3.org/1998/Math/MathML">
+  <mrow>
+    <mo>∃</mo>
+    <mi>x</mi>
+    <mo>∀</mo>
+    <mi>y</mi>
+    <mo>∀</mo>
+    <mi>z</mi>
+    <mo minsize="180%" maxsize="180%" stretchy="true" form="prefix">(</mo>
+    <mo minsize="120%" maxsize="120%" stretchy="true" form="prefix">(</mo>
+    <mi>F</mi>
+    <mo stretchy="false" form="prefix">(</mo>
+    <mi>x</mi>
+    <mo>,</mo>
+    <mi>y</mi>
+    <mo stretchy="false" form="postfix">)</mo>
+    <mo>∧</mo>
+    <mi>F</mi>
+    <mo stretchy="false" form="prefix">(</mo>
+    <mi>x</mi>
+    <mo>,</mo>
+    <mi>z</mi>
+    <mo stretchy="false" form="postfix">)</mo>
+    <mo>∧</mo>
+    <mo stretchy="false" form="prefix">(</mo>
+    <mi>y</mi>
+    <mo>≠</mo>
+    <mi>z</mi>
+    <mo stretchy="false" form="postfix">)</mo>
+    <mo minsize="120%" maxsize="120%" stretchy="true" form="postfix">)</mo>
+    <mo>→</mo>
+    <mo>¬</mo>
+    <mi>F</mi>
+    <mo stretchy="false" form="prefix">(</mo>
+    <mi>y</mi>
+    <mo>,</mo>
+    <mi>z</mi>
+    <mo stretchy="false" form="postfix">)</mo>
+    <mo minsize="180%" maxsize="180%" stretchy="true" form="postfix">)</mo>
+  </mrow>
+</math>

--- a/test/writer/mml/sphere_volume.test
+++ b/test/writer/mml/sphere_volume.test
@@ -243,7 +243,7 @@
           <mo>=</mo>
           <mi>ϕ</mi>
           <msubsup>
-            <mo minsize="1.8" maxsize="1.8" stretchy="false" form="prefix">|</mo>
+            <mo minsize="180%" maxsize="180%" stretchy="true" form="prefix">|</mo>
             <mn>0</mn>
             <mrow>
               <mn>2</mn>
@@ -259,7 +259,7 @@
             <mo stretchy="true" form="postfix">)</mo>
           </mrow>
           <msubsup>
-            <mo minsize="1.8" maxsize="1.8" stretchy="false" form="prefix">|</mo>
+            <mo minsize="180%" maxsize="180%" stretchy="true" form="prefix">|</mo>
             <mn>0</mn>
             <mi>π</mi>
           </msubsup>
@@ -275,7 +275,7 @@
             <mn>3</mn>
           </msup>
           <msubsup>
-            <mo minsize="1.8" maxsize="1.8" stretchy="false" form="prefix">|</mo>
+            <mo minsize="180%" maxsize="180%" stretchy="true" form="prefix">|</mo>
             <mn>0</mn>
             <mi>R</mi>
           </msubsup>


### PR DESCRIPTION
and setting the stretchy attribute.

- Change the mathml writer to format minsize and maxsize as percentages.
- Add a helper function to set an attribute that may already be set (since by default stretchy is false and I want it to be true for scaled delimiters).
- Set stretchy on scaled delimiters.
- Add a test with some stretched delimiters (which I found in the wild and led me to reporting this bug).
- Modify the one existing test that these changes seemed to break.

See also https://github.com/jgm/pandoc/issues/10869, I am hopeful that these fixes can make it to pandoc.