### PR TITLE
Revert adding cancel package to default environment.

### DIFF
--- a/src/Text/TeXMath/Types.hs
+++ b/src/Text/TeXMath/Types.hs
@@ -156,6 +156,6 @@ data Position = Under | Over
 -- | List of available packages
 type Env = [T.Text]
 
--- | Contains @amsmath@, @amssymbol@, and @cancel@
+-- | Contains @amsmath@ and @amssymbol@
 defaultEnv :: [T.Text]
-defaultEnv = ["amsmath", "amssymb", "cancel"]
+defaultEnv = ["amsmath", "amssymb"]

--- a/src/Text/TeXMath/Writers/TeX.hs
+++ b/src/Text/TeXMath/Writers/TeX.hs
@@ -263,15 +263,11 @@ writeExp (EBoxed e) = do
         tellGroup (writeExp e)
       else writeExp e
 writeExp (ECancel st e) = do
-    env <- asks mathEnv
-    if "cancel" `elem` env
-      then do
-        case st of
-          ForwardSlash -> tell [ControlSeq "\\cancel"]
-          BackSlash -> tell [ControlSeq "\\bcancel"]
-          XSlash -> tell [ControlSeq "\\xcancel"]
-        tellGroup (writeExp e)
-      else writeExp e
+  case st of
+    ForwardSlash -> tell [ControlSeq "\\cancel"]
+    BackSlash -> tell [ControlSeq "\\bcancel"]
+    XSlash -> tell [ControlSeq "\\xcancel"]
+  tellGroup (writeExp e)
 writeExp (EScaled size e)
   | case e of
          (ESymbol Open _)  -> True


### PR DESCRIPTION
As per my [comment](https://github.com/jgm/texmath/pull/271#issuecomment-3225886210) in #271, this PR removes the `cancel` package from the default environment. Additionally, it removes checking for the `cancel` package in the TeX writer.