### PR TITLE
TeX reader: handle \boldsymbol based on content style

### DIFF
--- a/src/Text/TeXMath/Readers/TeX/Commands.hs
+++ b/src/Text/TeXMath/Readers/TeX/Commands.hs
@@ -37,13 +37,12 @@ import Data.Text (Text)
 import Data.Ratio ((%))
 
 -- Note: cal and scr are treated the same way, as unicode is lacking such two different sets for those.
+-- Note: \boldsymbol and \bm are handled specially in TeX.hs (styled function).
 styleOps :: M.Map Text ([Exp] -> Exp)
 styleOps = M.fromList
           [ ("\\mathrm",     EStyled TextNormal)
           , ("\\mathup",     EStyled TextNormal)
           , ("\\mathbf",     EStyled TextNormal . (:[]) . EStyled TextBold)
-          , ("\\boldsymbol", EStyled TextBold)
-          , ("\\bm",         EStyled TextBold)
           , ("\\symbf",      EStyled TextBold)
           , ("\\mathbold",   EStyled TextBold)
           , ("\\pmb",        EStyled TextBold)

--- a/test/reader/tex/boldsymbol.test
+++ b/test/reader/tex/boldsymbol.test
@@ -1,0 +1,17 @@
+<<< tex
+\boldsymbol{\alpha + b = \Gamma \div D} + \bm{y}
+
+
+>>> native
+[ EGrouped
+    [ EStyled TextBoldItalic [ EIdentifier "\945" ]
+    , EStyled TextBoldItalic [ ESymbol Ord "+" ]
+    , EStyled TextBoldItalic [ EIdentifier "b" ]
+    , EStyled TextBoldItalic [ ESymbol Rel "=" ]
+    , EStyled TextBold [ EIdentifier "\915" ]
+    , EStyled TextBoldItalic [ ESymbol Ord "\247" ]
+    , EStyled TextBoldItalic [ EIdentifier "D" ]
+    ]
+, ESymbol Bin "+"
+, EStyled TextBoldItalic [ EIdentifier "y" ]
+]


### PR DESCRIPTION
## Summary
- Fix `\boldsymbol` and `\bm` commands to apply the correct bold style based on the content's default style
- Apply `TextBoldItalic` for content that is normally italic (latin letters, lowercase greek)
- Apply `TextBold` for content that is normally upright (uppercase greek letters, numbers)

Previously, `\boldsymbol` always applied `TextBold` regardless of the content, which was incorrect. In LaTeX, `\boldsymbol{x}` should produce bold italic x, while `\boldsymbol{\Gamma}` should produce bold upright Gamma.

## Test plan
- Added test case `test/reader/tex/boldsymbol.test`
- Verified: `\boldsymbol{x}` → TextBoldItalic
- Verified: `\boldsymbol{\Gamma}` → TextBold  
- Verified: `\boldsymbol{\alpha}` → TextBoldItalic
- Verified: `\bm{y}` → TextBoldItalic

## Close #280 
This is the effect of applying the modified texmath:

<img width="1774" height="491" alt="image" src="https://github.com/user-attachments/assets/1621bf04-ec0f-42b4-98d6-bb8ee9bbdb91" />
