### PR TITLE
Typst writer: map \\cap and \\bigcap to inter names

### DIFF
--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -308,9 +308,13 @@ tshow :: Show a => a -> Text
 tshow = T.pack . show
 
 typstSymbolMap :: M.Map Text Text
-typstSymbolMap = M.fromList $
-  ("\776", "dot.double") -- see #231
-  : [(s,name) | (name, _, s) <- typstSymbols]
+typstSymbolMap =
+  -- prefer inter names for typst-symbols (sect is deprecated)
+  M.insert "\x22C2" "inter.big" $
+  M.insert "\x2229" "inter" $
+  M.fromList $
+    ("\776", "dot.double") -- see #231
+    : [(s,name) | (name, _, s) <- typstSymbols]
 
 getAccentCommand :: Text -> Maybe Text
 getAccentCommand ac = do

--- a/test/writer/typst/deMorgans_law.test
+++ b/test/writer/typst/deMorgans_law.test
@@ -36,4 +36,4 @@
     (ESymbol TOver "\175")
 ]
 >>> typst
-not (p and q) arrow.l.r.double (not p) or (not q) overline(union.big_(i = 1)^n A_i) = sect.big_(i = 1)^n overline(A_i)
+not (p and q) arrow.l.r.double (not p) or (not q) overline(union.big_(i = 1)^n A_i) = inter.big_(i = 1)^n overline(A_i)

--- a/test/writer/typst/intersection_operators.test
+++ b/test/writer/typst/intersection_operators.test
@@ -1,0 +1,4 @@
+<<< native
+[ ESymbol Bin "\8745" , ESymbol Op "\8898" ]
+>>> typst
+inter inter.big

--- a/test/writer/typst/largeop1.test
+++ b/test/writer/typst/largeop1.test
@@ -76,9 +76,9 @@
     ]
 ]
 >>> typst
-upright("displaystyle: false largeop: false") & and.big or.big integral sum product union.big sect.big\
-upright("displaystyle: false largeop: true") & and.big or.big integral sum product union.big sect.big\
-upright("displaystyle: true largeop: false") & and.big or.big integral sum product union.big sect.big\
-upright("displaystyle: true largeop: true") & and.big or.big integral sum product union.big sect.big\
-upright("displaystyle: false largeop: default") & and.big or.big integral sum product union.big sect.big\
-upright("displaystyle: true largeop: default") & and.big or.big integral sum product union.big sect.big
+upright("displaystyle: false largeop: false") & and.big or.big integral sum product union.big inter.big\
+upright("displaystyle: false largeop: true") & and.big or.big integral sum product union.big inter.big\
+upright("displaystyle: true largeop: false") & and.big or.big integral sum product union.big inter.big\
+upright("displaystyle: true largeop: true") & and.big or.big integral sum product union.big inter.big\
+upright("displaystyle: false largeop: default") & and.big or.big integral sum product union.big inter.big\
+upright("displaystyle: true largeop: default") & and.big or.big integral sum product union.big inter.big

--- a/test/writer/typst/largeopPos3.test
+++ b/test/writer/typst/largeopPos3.test
@@ -8,4 +8,4 @@
     [ EIdentifier "A" , ESymbol Bin "\8745" , EIdentifier "B" ]
 ]
 >>> typst
-sect.big_(i = 0)^oo A sect B
+inter.big_(i = 0)^oo A inter B


### PR DESCRIPTION
# Summary

This updates `writeTypst` symbol mapping for intersection operators to emit non-deprecated Typst names:

- `\cap` now emits `inter` (was `sect`)
- `\bigcap` now emits `inter.big` (was `sect.big`)

This is an upstream fix in `texmath` for [pandoc’s downstream compatibility workaround](https://github.com/jgm/pandoc/pull/11592).

## Root cause

`Text.TeXMath.Writers.Typst` builds `typstSymbolMap` from `typstSymbols`.  
That symbol table includes both `inter`/`inter.big` and deprecated `sect`/`sect.big` aliases for the same codepoints.  
Map construction ended up resolving those duplicates to `sect` names.

## Changes

- Added explicit overrides in `typstSymbolMap` for:
  - `U+2229` -> `inter`
  - `U+22C2` -> `inter.big`
- Updated Typst golden tests that expected deprecated names.
- Added focused Typst writer test `intersection_operators.test` to lock both mappings.

Closes #287.

# Testing

Ran:
```bash
cabal test -f -server test-texmath --test-options='--pattern writer.typst'
```
Result: All 69 tests passed (0.11s)

Also locally reproduced pre-fix behavior via REPL (readTeX -> writeTypst) showing sect/sect.big, then verified tests now enforce inter/inter.big.