### PR TITLE
Fix Typst spacing after escaped expressions

### DIFF
--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -44,16 +44,23 @@ writeExps = go . map writeExp
  where
    go (a : b : es)
     | Just (bstart, _) <- T.uncons b
-    , Just (astart, _) <- T.uncons a
     , Just (_, aend) <- T.unsnoc a
     , bstart == '\'' -- avoid space before a prime #239
-      || bstart == '|' || aend == '|' || bstart == '\\' || astart == '\\' -- #286
+      || bstart == '|' || aend == '|'
+      || bstart == '\\' || isEscapedSymbol a -- #286
      = a <> go (b:es)
    go (a : as)
      = a <> if null as
                then mempty
                else " " <> go as
    go [] = mempty
+
+   -- A compound expression may start with an escape but end in an identifier.
+   -- Only a standalone escape suppresses the following space (#291).
+   isEscapedSymbol t =
+     case T.unpack t of
+       ['\\', _] -> True
+       _ -> False
 
 inParens :: Text -> Text
 inParens s = "(" <> s <> ")"

--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -55,6 +55,8 @@ writeExps = go . map writeExp
                else " " <> go as
    go [] = mempty
 
+   -- A compound expression may start with an escape but end in an identifier.
+   -- Only a standalone escape suppresses the following space (#291).
    isStandaloneEscape t =
      case T.uncons t of
        Just ('\\', rest) -> T.length rest == 1

--- a/src/Text/TeXMath/Writers/Typst.hs
+++ b/src/Text/TeXMath/Writers/Typst.hs
@@ -47,7 +47,7 @@ writeExps = go . map writeExp
     , Just (_, aend) <- T.unsnoc a
     , bstart == '\'' -- avoid space before a prime #239
       || bstart == '|' || aend == '|'
-      || bstart == '\\' || isEscapedSymbol a -- #286
+      || bstart == '\\' || isStandaloneEscape a -- #291, #286
      = a <> go (b:es)
    go (a : as)
      = a <> if null as
@@ -55,11 +55,9 @@ writeExps = go . map writeExp
                else " " <> go as
    go [] = mempty
 
-   -- A compound expression may start with an escape but end in an identifier.
-   -- Only a standalone escape suppresses the following space (#291).
-   isEscapedSymbol t =
-     case T.unpack t of
-       ['\\', _] -> True
+   isStandaloneEscape t =
+     case T.uncons t of
+       Just ('\\', rest) -> T.length rest == 1
        _ -> False
 
 inParens :: Text -> Text

--- a/test/regression/291.test
+++ b/test/regression/291.test
@@ -1,0 +1,4 @@
+<<< tex
+\mathcal G=\langle\mathcal N,(\mathcal A_i)_i,(u_i)_i\rangle\qquad (x)^\top\mathbf A
+>>> typst
+cal(G) = chevron.l cal(N)\,\(cal(A)_i\)_i\,\(u_i\)_i chevron.r #h(2em)\(x\)^top upright(bold(A))

--- a/test/regression/291.test
+++ b/test/regression/291.test
@@ -1,4 +1,6 @@
 <<< tex
-\mathcal G=\langle\mathcal N,(\mathcal A_i)_i,(u_i)_i\rangle\qquad (x)^\top\mathbf A
+)^n k \qquad
+(\mathbf x)^\top\mathbf A \qquad
+\mathcal G=\langle\mathcal N,(\mathcal A_i)_i,(u_i)_i\rangle
 >>> typst
-cal(G) = chevron.l cal(N)\,\(cal(A)_i\)_i\,\(u_i\)_i chevron.r #h(2em)\(x\)^top upright(bold(A))
+\)^n k #h(2em)\(upright(bold(x))\)^top upright(bold(A)) #h(2em) cal(G) = chevron.l cal(N)\,\(cal(A)_i\)_i\,\(u_i\)_i chevron.r


### PR DESCRIPTION
Fix for #291. Some context:

The fix for #286 removed spacing after expressions whose Typst output began with an escape. This worked as intended for standalone escaped symbols (such as `"\("`), but also affected compound expressions. For example:
```
$)^n k$
->
$\)^nk$
```
This output results in a Typst error: `error: unknown variable: nk`. The desired output here would be `$\)^n k$`.

This PR limits the space removal to standalone escapes and adds a regression test.

AI use disclosure: I work with LaTeX and Typst often, but only rarely with Haskell. Thus, this PR was written with assistance from Claude Fable 5. I could be missing something here.